### PR TITLE
fix: replace em dash with regular dash in ceos-trends description

### DIFF
--- a/skills/ceos-trends/SKILL.md
+++ b/skills/ceos-trends/SKILL.md
@@ -7,7 +7,7 @@ tools-used: [Read, Glob]
 
 # ceos-trends
 
-Longitudinal EOS health tracking — analyze how your organization is improving over time across all Six Key Components. While `ceos-dashboard` shows today's snapshot, `ceos-trends` answers the question every EOS coach asks: "Are we getting better?"
+Longitudinal EOS health tracking - analyze how your organization is improving over time across all Six Key Components. While `ceos-dashboard` shows today's snapshot, `ceos-trends` answers the question every EOS coach asks: "Are we getting better?"
 
 ## When to Use
 


### PR DESCRIPTION
One-character fix: em dash → regular dash on line 10 of ceos-trends SKILL.md.

Caught during PR review of #5.