### PR TITLE
fix: handle missing data/ gracefully in dashboard build

### DIFF
--- a/dashboard/build.py
+++ b/dashboard/build.py
@@ -99,6 +99,8 @@ def load_rocks(quarter="2026-Q1"):
 def load_scorecard():
     """Parse the metrics table from data/scorecard/metrics.md."""
     path = os.path.join(DATA_DIR, "scorecard", "metrics.md")
+    if not os.path.exists(path):
+        return []
     with open(path, encoding="utf-8") as f:
         text = f.read()
 
@@ -130,6 +132,8 @@ def load_scorecard():
 def load_accountability():
     """Parse seat sections from data/accountability.md."""
     path = os.path.join(DATA_DIR, "accountability.md")
+    if not os.path.exists(path):
+        return []
     with open(path, encoding="utf-8") as f:
         text = f.read()
 
@@ -275,6 +279,8 @@ def load_vision():
 def load_l10():
     """Parse the L10 standing agenda into structured sections."""
     path = os.path.join(DATA_DIR, "meetings", "l10", "agenda.md")
+    if not os.path.exists(path):
+        return {"schedule": "", "attendees": [], "sections": []}
     with open(path, encoding="utf-8") as f:
         text = f.read()
 


### PR DESCRIPTION
## Summary
- `load_scorecard`, `load_accountability`, and `load_l10` crashed with `FileNotFoundError` when `data/` hasn't been created yet (before running `setup.sh init`)
- Added `os.path.exists` checks matching the pattern already used by `load_vision`, `load_team`, and `load_calendar`
- Dashboard now builds successfully with empty data, producing a valid HTML page with zero entries

## Test plan
- [x] Verified `python3 dashboard/build.py` succeeds with no `data/` directory
- [ ] Confirm GitHub Actions build passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)