### PR TITLE
chore: add Dependabot for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"


### PR DESCRIPTION
Replaces the Renovate onboarding PR (#13, closed) with native GitHub Dependabot, scoped to the `github-actions` ecosystem.

### Why Dependabot instead of Renovate here

This repo's only dependency surface is `.github/workflows/dashboard.yml` (GitHub Actions + a pinned Python version). Across the repo fleet, **Renovate is reserved for the Hugo content sites** (aic, feld, foundry, zeroknowledge), which all extend the shared `github>bradfeld/hugo-common` preset for the Hugo build toolchain. Everything else leans on Dependabot as the baseline — that `hugo-common` preset's own design notes call out relying on GitHub-native Dependabot for security coverage.

Renovate buys nothing extra on this repo: `main` branch protection requires a human approval, so Renovate's automerge can't fire — every bot PR would wait for manual review, exactly like Dependabot. So we use the lighter-weight native tool and avoid onboarding a 6th repo onto Renovate.

### What this does

```yaml
version: 2
updates:
  - package-ecosystem: "github-actions"
    directory: "/"
    schedule:
      interval: "weekly"
    commit-message:
      prefix: "chore"
```

Dependabot will open weekly PRs for outdated actions (currently: `actions/checkout` v4→v7, `actions/setup-python` v5→v6, `actions/upload-pages-artifact` v3→v5, `actions/deploy-pages` v4→v5) for manual review. The Python `3.11→3.14` bump Renovate proposed is a real runtime change and intentionally stays a human decision, not covered here.