### PR TITLE
fix: dashboard build degrades gracefully when data files are absent

### DIFF
--- a/dashboard/build.py
+++ b/dashboard/build.py
@@ -151,6 +151,8 @@ def load_all_rocks():
 def load_scorecard():
     """Parse the metrics table from data/scorecard/metrics.md."""
     path = os.path.join(DATA_DIR, "scorecard", "metrics.md")
+    if not os.path.exists(path):
+        return []
     with open(path, encoding="utf-8") as f:
         text = f.read()
 
@@ -182,6 +184,8 @@ def load_scorecard():
 def load_accountability():
     """Parse seat sections from data/accountability.md."""
     path = os.path.join(DATA_DIR, "accountability.md")
+    if not os.path.exists(path):
+        return []
     with open(path, encoding="utf-8") as f:
         text = f.read()
 
@@ -327,6 +331,8 @@ def load_vision():
 def load_l10():
     """Parse the L10 standing agenda into structured sections."""
     path = os.path.join(DATA_DIR, "meetings", "l10", "agenda.md")
+    if not os.path.exists(path):
+        return {"schedule": "", "attendees": [], "sections": []}
     with open(path, encoding="utf-8") as f:
         text = f.read()
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -384,3 +384,45 @@ class TestBuildIntegration:
         assert "rocks_by_quarter" in data
         assert "quarters" in data
         assert "current_quarter" in data
+
+
+# ---------------------------------------------------------------------------
+# Missing-data resilience
+# ---------------------------------------------------------------------------
+
+class TestMissingDataGraceful:
+    """Loaders must degrade gracefully when data files are absent.
+
+    The public repo ships without the private data/ tree, so the dashboard
+    workflow builds against an empty data dir. Regression: the build failed at
+    load_scorecard with FileNotFoundError on data/scorecard/metrics.md.
+    """
+
+    def test_scorecard_missing_returns_empty(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(build, "DATA_DIR", str(tmp_path))
+        assert build.load_scorecard() == []
+
+    def test_accountability_missing_returns_empty(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(build, "DATA_DIR", str(tmp_path))
+        assert build.load_accountability() == []
+
+    def test_l10_missing_returns_empty_shape(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(build, "DATA_DIR", str(tmp_path))
+        assert build.load_l10() == {"schedule": "", "attendees": [], "sections": []}
+
+    def test_full_build_with_no_data(self, monkeypatch, tmp_path):
+        """The whole pipeline must complete against an empty data dir (the CI scenario)."""
+        data_dir = tmp_path / "data"  # deliberately not created → fully empty
+        docs_dir = tmp_path / "docs"
+        monkeypatch.setattr(build, "DATA_DIR", str(data_dir))
+        monkeypatch.setattr(build, "DOCS_DIR", str(docs_dir))
+        monkeypatch.delenv("DASHBOARD_PASSWORD", raising=False)
+        monkeypatch.delenv("GITHUB_WRITE_TOKEN", raising=False)
+
+        build.build()
+
+        out = docs_dir / "index.html"
+        assert out.exists(), "index.html should still be produced with no data"
+        html = out.read_text(encoding="utf-8")
+        assert html.startswith("<!DOCTYPE html>")
+        assert "tab-scorecard" in html  # tabs render even with empty datasets


### PR DESCRIPTION
## Problem

The "Build & Deploy EOS Dashboard" workflow has failed on **every** run — including before the recent Dependabot action bumps (which are unrelated). Root cause, surfaced by a `workflow_dispatch` run on `main`:

```
FileNotFoundError: [Errno 2] No such file or directory: '.../data/scorecard/metrics.md'
  → dashboard/build.py line 154, load_scorecard()
```

The public repo ships **without** the private `data/` tree, so the build runs against an empty data dir. Three loaders used a bare `open()` and crashed on the missing file: `load_scorecard`, `load_accountability`, and `load_l10` (they run back-to-back in `build()`, so fixing only the first would just move the crash to the next).

## Fix

Add the same `os.path.exists` guard the sibling loaders (`load_vision`, `load_calendar`, `load_team`) already use — each returns its empty default:

- `load_scorecard` → `[]`
- `load_accountability` → `[]`
- `load_l10` → `{"schedule": "", "attendees": [], "sections": []}`

No behavior change when the data files **are** present.

## Tests

Adds `TestMissingDataGraceful`: the three loaders return their empty defaults with an empty data dir, plus a full `build()` against an empty data dir (reproduces the exact CI scenario and asserts `index.html` is still produced).

- Full suite: **52 passed** (48 existing + 4 new).
- Verified the real `dashboard/build.py` now exits 0 against a data-less checkout, producing `docs/index.html` with all datasets at 0.