### PR TITLE
feat: sync private backlog — 4 skills, 7 templates, kit.yaml

### DIFF
--- a/kit.yaml
+++ b/kit.yaml
@@ -1,0 +1,23 @@
+# Kit Contract v1 — CEOS's conforming kit manifest (CEO-49).
+# Normative schema: authoros contract/kit.schema.md; normative contract:
+# authoros contract/KIT-CONTRACT.md (AOS-48). The contract is the INTERFACE —
+# CEOS's standalone installer (setup.sh) and publish.sh public-export flow
+# stay its own implementation.
+contract_version: 1
+kit:
+  id: ceos
+  name: "CEOS"
+  version: 1.0.0            # first versioned release marker (kit predates the contract)
+  repo: https://github.com/bradfeld/ceos.git   # canonical PUBLIC clone URL (publish.sh syncs from the private source repo)
+commands:
+  invocation: "ceos-* skills (Claude-interpreted; see skills/ and README.md)"
+installer:
+  entry: setup.sh
+  args: "run from the cloned repo root"
+capabilities_required: []   # standalone-only today — no hosted-agent tier
+# No tenant_manifest block: CEOS has no tenant model — a CEO clones the kit directly.
+delivery:
+  notes: >-
+    Standalone-tier kit: a CEO clones kit.repo and runs setup.sh directly. If a
+    hosted CEOS agent ever ships, delivery follows the Kit Contract v1 mechanism
+    (authoros contract/KIT-CONTRACT.md, "Delivery (v1 mechanism)").

--- a/skills/ceos-assistance/SKILL.md
+++ b/skills/ceos-assistance/SKILL.md
@@ -1,0 +1,382 @@
+---
+name: ceos-assistance
+description: Use when managing daily operational delegation through The Stack and structured leader-assistant standups
+file-access: [data/assistance/, templates/assistance-stack.md, templates/assistance-daily.md, data/accountability.md, data/delegate/]
+tools-used: [Read, Write, Glob]
+---
+
+# ceos-assistance
+
+Manage the daily operational delegation workflow between a leader and their assistant using "The Stack" — a batch delegation queue. This skill implements the 5 disciplines of The Assistance Track: batching, The Stack, the daily meeting, the assistant's judgment, and a weekly review. It complements `ceos-delegate`, which handles *strategic* delegation (what SHOULD be delegated), by managing *operational* delegation (HOW items are delegated day-to-day).
+
+**Not for:** Strategic delegation decisions (use `ceos-delegate`), task tracking without a leader-assistant relationship (use `ceos-todos`), or meeting facilitation (use `ceos-l10`). The Assistance Track is specifically about the daily delegation workflow between a leader and their dedicated assistant.
+
+## When to Use
+
+- "Add to the stack" or "stack this for my assistant"
+- "Run the daily meeting" or "daily standup with my assistant"
+- "Review the stack" or "what's on the stack?"
+- "Weekly assistance review" or "how's delegation going this week?"
+- "Show stuck items" or "what's been on the stack too long?"
+- "Hand off [item] to [assistant]" or "mark [item] as done"
+- Any discussion about daily delegation queues, assistant standups, or The Assistance Track
+
+## Context
+
+### Finding the CEOS Repository
+
+Search upward from the current directory for the `.ceos` marker file. This file marks the root of the CEOS repository.
+
+If `.ceos` is not found, stop and tell the user: "Not in a CEOS repository. Clone your CEOS repo and run setup.sh first."
+
+**Sync before use:** Once you find the CEOS root, run `git -C <ceos_root> pull --ff-only --quiet 2>/dev/null` to get the latest data from teammates. If it fails (conflict or offline), continue silently with local data.
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `data/assistance/stack/` | Stack items — one file per delegation item |
+| `data/assistance/daily/` | Daily meeting logs — one file per meeting |
+| `templates/assistance-stack.md` | Template for new stack items |
+| `templates/assistance-daily.md` | Template for daily meeting logs |
+| `data/accountability.md` | Source of leader-assistant relationships (read-only — use ceos-accountability to modify) |
+| `data/delegate/` | Delegate and Elevate audits (read-only — reference for delegation context) |
+
+### Stack Item Format
+
+Each stack item is a markdown file at `data/assistance/stack/stack-NNN-slug.md` with YAML frontmatter:
+
+```yaml
+id: "stack-001"
+title: "Schedule board meeting"
+from: "Brad Feld"
+to: "Sarah Chen"
+urgency: this_week        # today | this_week | whenever
+status: pending           # pending | handed_off | done
+created: "2026-02-16"
+handed_off: null           # Date when handed to assistant
+completed: null            # Date when marked done
+```
+
+**File naming:** `stack-NNN-slug.md` — zero-padded numeric ID, title slugified.
+
+### Daily Meeting Log Format
+
+Each daily meeting is a markdown file at `data/assistance/daily/YYYY-MM-DD.md` with YAML frontmatter:
+
+```yaml
+date: "2026-02-16"
+leader: "Brad Feld"
+assistant: "Sarah Chen"
+items_reviewed: 5
+items_handed_off: 3
+items_completed: 1
+duration_minutes: 15
+```
+
+### Urgency Values
+
+| Value | Meaning | Expected Turnaround |
+|-------|---------|-------------------|
+| `today` | Needs attention today | Same day |
+| `this_week` | Should be completed this week | Within the week |
+| `whenever` | No time pressure, do when convenient | Best effort |
+
+### Status Values
+
+| Value | Meaning | When Set |
+|-------|---------|----------|
+| `pending` | On the stack, not yet handed off | Item creation |
+| `handed_off` | Discussed in daily meeting, assistant is working on it | During Daily mode |
+| `done` | Completed | During Daily or Stack mode |
+
+### The 5 Disciplines
+
+The Assistance Track is built on 5 disciplines that make delegation work:
+
+1. **Batching** — Don't interrupt your assistant throughout the day. Collect items on The Stack.
+2. **The Stack** — A single queue of everything you need to delegate. Items wait here until the daily meeting.
+3. **The Daily Meeting** — A structured 5-15 minute standup to review The Stack, hand off items, and check on progress.
+4. **The Assistant's Judgment** — Once handed off, trust the assistant to handle it. Don't micromanage.
+5. **The Weekly Review** — A weekly check on stuck items, completion rates, and delegation health.
+
+### Leader-Assistant Relationship
+
+The leader-assistant relationship is derived from `data/accountability.md`. Look for reporting relationships where one person's seat includes assistant-type responsibilities (Executive Assistant, Office Manager, etc.).
+
+If no clear assistant relationship is found in the accountability chart, ask the user: "Who is your assistant? (I couldn't find a clear assistant relationship in the accountability chart.)"
+
+## Process
+
+### Mode: Stack
+
+Use when adding new items to The Stack. This is the primary way a leader batches delegation throughout the day.
+
+#### Step 1: Identify the Relationship
+
+Determine the leader and assistant. If only one leader-assistant pair exists in `data/accountability.md`, use it automatically. If multiple exist or none is clear, ask the user.
+
+Check for existing stack items to determine the next ID:
+
+1. Scan `data/assistance/stack/` for all `stack-NNN-*.md` files
+2. Also check `data/assistance/daily/` meeting logs for any referenced IDs
+3. Find the highest numeric ID
+4. Increment by 1
+
+#### Step 2: Capture the Item
+
+Ask for the item details:
+
+1. **Title:** Short description of the task ("Schedule board meeting", "Order new monitors")
+2. **Urgency:** today, this_week, or whenever
+3. **Details:** Any additional context or instructions (optional)
+
+For quick stacking, accept a one-liner: "Stack: Schedule board meeting - this_week" and parse it.
+
+#### Step 3: Create the Stack Item
+
+Create a new file from `templates/assistance-stack.md`:
+
+- Generate the next sequential ID (`stack-NNN`)
+- Slugify the title for the filename
+- Fill in the frontmatter fields
+- Add any details to the body
+
+Show the file before writing. Ask: "Add this to the stack?"
+
+#### Step 4: Confirm
+
+After writing, display a brief confirmation:
+
+```
+Added to stack: stack-003 "Schedule board meeting" (this_week)
+Stack total: 5 pending items
+```
+
+---
+
+### Mode: Daily
+
+Use when running the structured daily standup between a leader and their assistant. This is the 5-15 minute meeting where The Stack is reviewed and items are handed off.
+
+#### Step 1: Load the Stack
+
+Read all files from `data/assistance/stack/` via `Glob("data/assistance/stack/stack-*.md")`. Parse YAML frontmatter.
+
+If no items exist: "The stack is empty. Nothing to review today. Add items with Stack mode throughout the day."
+
+Separate items by status:
+- **Pending** — needs to be discussed and handed off
+- **Handed off** — check on progress
+- **Today urgency** — highlight these first regardless of status
+
+#### Step 2: Display the Agenda
+
+```
+Daily Standup — [Date]
+━━━━━━━━━━━━━━━━━━━━━
+Leader: [Name]  |  Assistant: [Name]
+
+🔴 TODAY (needs attention now):
+  stack-005: "Call insurance broker" (pending)
+  stack-003: "Send revised proposal" (handed_off — 2 days ago)
+
+📋 PENDING (hand off today):
+  stack-007: "Order office supplies" (this_week)
+  stack-008: "Research conference venues" (whenever)
+
+🔄 IN PROGRESS (check status):
+  stack-001: "Schedule board meeting" (handed_off — 1 day ago)
+  stack-004: "Book travel for March" (handed_off — 3 days ago)
+```
+
+#### Step 3: Walk Through Each Item
+
+For each item in the agenda, ask the leader:
+
+**For pending items:**
+- "Hand off to [assistant]?" → Update status to `handed_off`, set `handed_off` date
+- "Defer?" → Keep as pending, optionally update urgency
+- "Cancel?" → Remove from stack (delete file)
+
+**For handed-off items:**
+- "Done?" → Update status to `done`, set `completed` date
+- "Still in progress?" → No change, note in meeting log
+- "Stuck?" → Note the blocker, optionally escalate urgency
+
+**For today-urgency items:**
+- Highlight with extra emphasis. These should be resolved or actively worked on by end of day.
+
+#### Step 4: Capture New Items
+
+After reviewing existing items: "Any new items to add to the stack?"
+
+If yes, follow Stack mode Steps 2-3 for each new item.
+
+#### Step 5: Save the Meeting Log
+
+Create a daily meeting log from `templates/assistance-daily.md`:
+
+- File: `data/assistance/daily/YYYY-MM-DD.md`
+- Fill in frontmatter: date, leader, assistant, counts
+- Populate the Stack Review table with decisions from Step 3
+- Populate the New Items table from Step 4
+- Record any action items discussed
+
+Show the complete meeting log before writing. Ask: "Save this daily meeting log?"
+
+#### Step 6: Update Stack Items
+
+After the meeting log is saved, update all stack item files based on the decisions:
+
+- Set `handed_off` date on newly handed-off items
+- Set `completed` date and status on done items
+- Update urgency if changed
+- Delete cancelled items
+
+Display a brief summary:
+
+```
+Daily standup complete:
+  Handed off: 2 items
+  Completed: 1 item
+  Still pending: 3 items
+  New items added: 1
+  Duration: ~10 minutes
+```
+
+---
+
+### Mode: Review
+
+Use when running the weekly review of The Assistance Track. This checks delegation health, identifies stuck items, and surfaces patterns.
+
+#### Step 1: Load All Data
+
+Read all stack items from `data/assistance/stack/` and all daily meeting logs from `data/assistance/daily/`. Parse YAML frontmatter for both.
+
+If no data exists: "No Assistance Track data found. Start by adding items with Stack mode and running Daily meetings."
+
+#### Step 2: Stack Health Summary
+
+```
+Assistance Track — Weekly Review
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Stack Status:
+  Pending: 4 items
+  Handed off: 3 items
+  Completed this week: 5 items
+  Total active: 7 items
+
+Urgency breakdown:
+  Today: 1 item ⚠️
+  This week: 3 items
+  Whenever: 3 items
+```
+
+#### Step 3: Flag Stuck Items
+
+Items that have been on the stack for more than 3 days without progress are flagged:
+
+```
+⚠️ Stuck Items (3+ days without progress):
+  stack-004: "Book travel for March" — handed_off 5 days ago
+    → Consider: Follow up with [assistant], escalate urgency, or reassign
+  stack-006: "Update CRM contacts" — pending 4 days ago
+    → Consider: Has this been discussed in a daily meeting?
+```
+
+For each stuck item, offer options:
+- Escalate urgency (e.g., `whenever` → `this_week`)
+- Add a note about the blocker
+- Reassign to someone else
+- Close as no longer needed
+
+#### Step 4: Meeting Cadence Check
+
+Review daily meeting logs for the past week:
+
+```
+Daily Meeting Cadence:
+  Meetings this week: 4 / 5 expected
+  Missing: Wednesday (2026-02-12)
+  Avg items per meeting: 3.5
+  Avg duration: 12 minutes
+```
+
+If fewer than 3 meetings in a week: "⚠️ Only [N] daily meetings this week. The daily standup is the core discipline — consistency matters more than perfection."
+
+#### Step 5: Delegation Trends
+
+If enough data exists (2+ weeks of daily meetings):
+
+```
+Delegation Trends (last 2 weeks):
+  Items added: 12
+  Items completed: 8
+  Completion rate: 67%
+  Avg time to completion: 2.3 days
+  Most common urgency: this_week (58%)
+```
+
+#### Step 6: Cross-Reference with Delegate and Elevate
+
+Optionally read `data/delegate/` to check if any Quadrant 3 or 4 tasks from the D&E audit are showing up as stuck stack items. This connects strategic delegation decisions to daily execution:
+
+"Note: stack-004 'Book travel for March' relates to the Q3 task 'Travel logistics' from [person]'s D&E audit. Consider permanent delegation of this category."
+
+#### Step 7: Suggest Actions
+
+Based on the review, suggest 1-3 specific actions:
+
+```
+Suggested Actions:
+  1. Follow up on 2 stuck items (stack-004, stack-006)
+  2. Schedule the missed Wednesday daily meeting
+  3. Consider delegating 'travel logistics' permanently (shows up repeatedly)
+
+Would you like to take action on any of these?
+```
+
+## Output Format
+
+**Stack:** Brief confirmation with item ID, title, urgency, and current stack count.
+
+**Daily:** Structured agenda sorted by urgency (today first), followed by pending, then in-progress. Interactive walkthrough with decisions recorded. Summary showing handoffs, completions, and new items.
+
+**Review:** Dashboard-style summary with stack health, stuck items, meeting cadence, and delegation trends. Actionable suggestions based on patterns. Complete data shown before any file modifications.
+
+## Guardrails
+
+- **Always show the complete file before writing.** Never create or modify a stack item or meeting log without showing the content and getting approval.
+- **Don't auto-invoke other skills.** When review results suggest creating To-Dos or running D&E, mention the option but let the user decide. Say "Would you like to create a To-Do for this?" rather than doing it automatically.
+- **Sensitive data warning.** On first use in a session, remind the user: "Assistance Track data includes delegation details and daily meeting notes. This repo should be private."
+- **Respect the batch discipline.** Don't encourage adding items AND immediately handing them off. The point of The Stack is to batch — items should generally wait for the next daily meeting to be handed off. Exception: `today` urgency items may warrant immediate handoff.
+- **Don't micromanage the assistant.** Once an item is `handed_off`, trust the assistant. The Review mode flags stuck items, but the daily meeting is for status checks, not detailed oversight.
+- **One leader-assistant pair per session.** If the organization has multiple leaders with assistants, each session should focus on one relationship. Ask which pair at the start if ambiguous.
+- **Stack IDs are permanent.** Once a `stack-NNN` ID is assigned, it's never reused, even if the item is completed or deleted. This ensures meeting logs always reference valid IDs.
+
+## Integration Notes
+
+### Accountability Chart (ceos-accountability)
+
+- **Direction:** Read
+- **What data:** `data/accountability.md` — seat names, owners, reporting relationships
+- **Purpose:** Identifies the leader-assistant relationship. The assistant is typically the person in a seat with assistant-type responsibilities (Executive Assistant, Office Manager) who reports to the leader. If the accountability chart doesn't define this clearly, the user specifies the relationship.
+
+### Delegate and Elevate (ceos-delegate)
+
+- **Direction:** Read
+- **What data:** `data/delegate/firstname-lastname.md` — quadrant assignments, delegation progress
+- **Purpose:** Review mode cross-references stuck stack items with Q3/Q4 tasks from D&E audits. Recurring stack items in the same category may indicate a task that should be permanently delegated rather than repeatedly stacked. This connects strategic delegation decisions to daily operational execution.
+
+### To-Dos (ceos-todos)
+
+- **Direction:** Related
+- **What data:** `data/todos/` — actions from the daily meeting can be promoted to tracked To-Dos via `ceos-todos`
+- **Purpose:** Some items from the daily standup may need formal tracking with due dates and completion rates beyond the stack's simpler lifecycle. Currently stored as action items in the meeting log.
+
+### Write Principle
+
+**Only `ceos-assistance` writes to `data/assistance/`.** Other skills may reference assistance data for delegation context, but do not modify stack items or daily meeting logs.

--- a/skills/ceos-cashflow/SKILL.md
+++ b/skills/ceos-cashflow/SKILL.md
@@ -1,0 +1,303 @@
+---
+name: ceos-cashflow
+description: Use when assessing and optimizing the 8 financial levers that drive cash flow and profitability
+file-access: [data/cashflow/, templates/cashflow-assessment.md, data/accountability.md, data/scorecard/]
+tools-used: [Read, Write, Glob]
+---
+
+# ceos-cashflow
+
+The 8 Cash Flow Drivers (EOS Toolbox tool #10). A facilitated workshop for leadership teams to identify and optimize the eight key financial levers that impact cash flow and profitability: Price, Volume, COGS/Margin, A/R Days, A/P Days, Inventory/WIP, Operating Expenses, and Debt Structure.
+
+**Not for:** Weekly scorecard tracking (use `ceos-scorecard`), general issue resolution (use `ceos-ids`), or Rock setting (use `ceos-rocks`). This skill is for the structured cash flow driver assessment — a strategic conversation about financial levers.
+
+## When to Use
+
+- "Assess our cash flow" or "8 cash flow drivers"
+- "Cash flow drivers" or "financial optimization"
+- "Review our financial levers" or "profitability drivers"
+- "Where can we improve margins?"
+- "Cash flow driver review" or "quarterly cash flow check-in"
+- "Show cash flow history" or "how have our drivers changed?"
+
+## Context
+
+### Finding the CEOS Repository
+
+Before doing anything:
+
+1. Search upward from the current directory for a `.ceos` marker file
+2. If not found, tell the user: "I can't find a CEOS repository. Clone it with `git clone https://github.com/bradfeld/ceos.git` and run `./setup.sh init`."
+3. If found, set `CEOS_ROOT` to that directory
+4. Run `git -C "$CEOS_ROOT" pull --ff-only` to sync latest data (skip if offline or if pull fails — work with local data)
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `data/cashflow/` | Cash flow driver assessments (one per session) |
+| `data/accountability.md` | Team members for suggesting driver owners |
+| `data/scorecard/metrics.md` | Existing metrics that may overlap with cash flow drivers |
+| `templates/cashflow-assessment.md` | Template for new assessment files |
+
+### The 8 Cash Flow Drivers
+
+| # | Driver | Key Question | Typical Metric |
+|---|--------|-------------|----------------|
+| 1 | **Price** | Can you increase prices? | Average selling price, price per unit |
+| 2 | **Volume** | Can you sell more? | Units sold, transactions, customers |
+| 3 | **COGS / Margin** | Can you reduce cost of goods? | Gross margin %, COGS as % of revenue |
+| 4 | **A/R Days** | Can you collect faster? | Days sales outstanding (DSO) |
+| 5 | **A/P Days** | Can you negotiate better terms? | Days payable outstanding (DPO) |
+| 6 | **Inventory / WIP** | Can you reduce inventory? | Inventory turnover, WIP backlog |
+| 7 | **Operating Expenses** | Where can you cut overhead? | OpEx as % of revenue, specific line items |
+| 8 | **Debt Structure** | Is debt optimized? | Debt-to-equity, interest rate, term mix |
+
+**Note:** Not all 8 drivers apply equally to every business. A software company may have minimal inventory. A services firm may have no COGS. The skill handles this — drivers can be marked as "none" potential when they don't apply.
+
+### Driver Improvement Potential
+
+| Value | Meaning |
+|-------|---------|
+| `high` | Significant upside — this driver should be a top priority |
+| `medium` | Moderate improvement possible with focused effort |
+| `low` | Minor gains available — not a priority this quarter |
+| `none` | Already optimized or not applicable to this business |
+
+### Assessment Status
+
+| Value | Meaning |
+|-------|---------|
+| `in_progress` | Assessment started but not all drivers evaluated |
+| `complete` | All drivers assessed and priorities set |
+
+## Process
+
+### Mode: Assess
+
+**Trigger:** User wants to evaluate all 8 cash flow drivers from scratch.
+
+**Step 1: Gather context**
+
+Read `data/accountability.md` to identify potential driver owners. If the file doesn't exist, skip owner suggestions — ask the user for each driver's owner directly.
+
+Read `data/scorecard/metrics.md` (if it exists) to identify metrics already being tracked that relate to cash flow drivers. Note any overlaps — don't duplicate existing scorecard measurables.
+
+**Step 2: Walk through the 8 drivers**
+
+For each driver (1 through 8):
+
+1. Display the driver name, key question, and typical metric from the reference table
+2. If a related scorecard metric exists, note it: "Your Scorecard already tracks [metric] — you may want to reference that as your baseline."
+3. Ask the user:
+   - **Current state:** What's the current situation for this driver?
+   - **Improvement potential:** High, medium, low, or none?
+   - **Baseline metric:** What's the current value? (Store as a string — can be "\$52K/month", "Net 30", "45 days", etc.)
+   - **Target metric:** Where do you want this to be?
+   - **Owner:** Who is accountable for this driver? (Suggest from accountability chart if available)
+   - **Notes:** Any additional context?
+
+If the user wants to skip a driver (e.g., "Inventory doesn't apply to us"), set potential to `none` and note "Not applicable" in current_state. Move to the next driver.
+
+**Step 3: Prioritize**
+
+After all 8 drivers are assessed, display a summary table:
+
+| # | Driver | Potential | Owner | Baseline | Target |
+|---|--------|-----------|-------|----------|--------|
+| ... | ... | ... | ... | ... | ... |
+
+Ask the user to rank their top 3-5 focus drivers. Assign `priority_rank` values (1 = highest priority). Drivers not in the top 3-5 get `null` for priority_rank.
+
+**Step 4: Create assessment file**
+
+Generate the complete file from `templates/cashflow-assessment.md`. Populate all frontmatter fields and body sections.
+
+**Show the complete file** to the user before writing. Ask: "Save this assessment?"
+
+Write to `data/cashflow/YYYY-MM-DD.md` (using today's date). If a file already exists for today, use suffix: `YYYY-MM-DD-2.md`.
+
+Set frontmatter `status: complete`.
+
+**Step 5: Next steps**
+
+After saving, mention (but don't auto-invoke):
+- "Driver improvements with high potential could become Rocks for next quarter (use `ceos-rocks`)"
+- "Driver problems that need investigation could become Issues (use `ceos-ids`)"
+- "Consider adding key driver metrics to your Scorecard (use `ceos-scorecard`)"
+
+### Mode: Review
+
+**Trigger:** User wants a quarterly check-in on their prioritized cash flow drivers.
+
+**Step 1: Load assessments**
+
+Read all files from `data/cashflow/` via Glob. Parse YAML frontmatter. Sort by date (newest first).
+
+If no assessments exist: "No cash flow assessments found. Run an assessment first to establish your baseline."
+
+**Step 2: Find the latest assessment**
+
+Display the most recent completed assessment's prioritized drivers (those with `priority_rank` set):
+
+| Priority | Driver | Baseline | Target | Owner |
+|----------|--------|----------|--------|-------|
+| 1 | [driver] | [baseline] | [target] | [owner] |
+| 2 | [driver] | [baseline] | [target] | [owner] |
+| ... | ... | ... | ... | ... |
+
+**Step 3: Collect current values**
+
+For each prioritized driver, ask: "What's the current value for [Driver]? (Baseline was [baseline], target is [target])"
+
+**Step 4: Display progress**
+
+| Priority | Driver | Baseline | Current | Target | Direction |
+|----------|--------|----------|---------|--------|-----------|
+| 1 | Price | \$45/unit | \$48/unit | \$55/unit | Improving |
+| 2 | A/R Days | 45 days | 42 days | 30 days | Improving |
+| 3 | OpEx | 35% of rev | 36% of rev | 30% of rev | Stalling |
+
+**Direction** values:
+- **Improving** — Moving toward target
+- **Stalling** — No change or very minor movement
+- **Regressing** — Moving away from target
+- **Target hit** — Current meets or exceeds target
+
+**Step 5: Flag and suggest**
+
+For stalling or regressing drivers, suggest:
+- "Consider creating an Issue to investigate why [Driver] is stalling (use `ceos-ids`)"
+- "A focused Rock on [Driver] improvement could help (use `ceos-rocks`)"
+
+**Step 6: Save review (optional)**
+
+Ask if the user wants to save this review as a new assessment. If yes, create a new file capturing the current state as the new baseline. This becomes the comparison point for the next review.
+
+### Mode: History
+
+**Trigger:** User wants to see cash flow driver trends over time.
+
+**Step 1: Load all assessments**
+
+Read all files from `data/cashflow/` via Glob. Parse YAML frontmatter. Sort by date (oldest first).
+
+If no assessments exist: "No cash flow assessments found yet."
+
+If only one assessment: Display it, noting "Only one assessment on record. Run another assessment later to see trends."
+
+**Step 2: Assessment timeline**
+
+| Date | Drivers Assessed | High | Medium | Low | None | Top Priorities |
+|------|-----------------|------|--------|-----|------|---------------|
+| 2026-02-15 | 8 | 3 | 2 | 2 | 1 | Price, A/R Days, OpEx |
+| 2026-05-10 | 8 | 2 | 3 | 2 | 1 | A/R Days, Volume, OpEx |
+
+**Step 3: Per-driver trends**
+
+For each driver that has been prioritized in at least one assessment:
+
+```
+Price:  high → medium → low  (improving — was a top priority, now optimized)
+A/R Days:  high → high → medium  (improving slowly — still needs attention)
+OpEx:  medium → high → high  (worsening — consider escalating to an Issue)
+```
+
+**Step 4: Insights**
+
+- Which drivers have been consistently prioritized (may need a Rock)
+- Which drivers improved and were deprioritized (success stories)
+- Which drivers have worsened (may need an IDS investigation)
+
+**Step 5: Drill-down**
+
+Offer: "Would you like to see the full details of any specific assessment?"
+
+If yes, display the complete assessment file.
+
+## Output Format
+
+### Assess Mode Summary
+
+After completing the assessment, display:
+
+```
+Cash Flow Assessment — YYYY-MM-DD
+
+8 Drivers Assessed:
+  High potential:   [N] drivers
+  Medium potential:  [N] drivers
+  Low potential:     [N] drivers
+  Not applicable:    [N] drivers
+
+Top Priorities:
+  1. [Driver] — [Baseline] → [Target] (Owner: [Name])
+  2. [Driver] — [Baseline] → [Target] (Owner: [Name])
+  3. [Driver] — [Baseline] → [Target] (Owner: [Name])
+
+Saved to: data/cashflow/YYYY-MM-DD.md
+```
+
+### Review Mode Summary
+
+```
+Cash Flow Review — YYYY-MM-DD
+
+Comparing to assessment from [prior date]:
+
+  Improving:  [N] drivers
+  Stalling:   [N] drivers
+  Regressing: [N] drivers
+  Target hit: [N] drivers
+
+[Table of prioritized drivers with progress]
+```
+
+### History Mode Summary
+
+```
+Cash Flow History — [N] assessments
+
+First assessment: YYYY-MM-DD
+Latest assessment: YYYY-MM-DD
+
+[Assessment timeline table]
+[Per-driver trend arrows]
+```
+
+## Guardrails
+
+- **Always show the complete file before writing.** Never save an assessment without the user seeing and approving the full content.
+- **Don't auto-invoke skills.** When assessment results suggest creating Rocks, Issues, or Scorecard metrics, mention the option but let the user decide. Say "Would you like to create a Rock for this?" rather than doing it automatically.
+- **Sensitive data warning.** On first use in a session, remind the user: "Cash flow assessments contain sensitive financial information (revenue targets, cost structures, debt details). Ensure this repository is private."
+- **Don't prescribe financial strategies.** This is a facilitation guide, not financial advice. Present the framework and record the team's decisions. Don't suggest specific pricing strategies, cost-cutting measures, or debt restructuring approaches.
+- **One full assessment per session.** Walking through all 8 drivers is a substantial conversation. Don't rush — each driver deserves focused discussion.
+- **Metrics are strings, not numbers.** Financial values come in many formats (\$52K, 45 days, Net 30, 35% of revenue). Store them as human-readable strings. The skill facilitates comparison through display, not computation.
+
+## Integration Notes
+
+### Accountability Chart (Read)
+
+- **Direction:** Read
+- **What data:** `data/accountability.md`
+- **Purpose:** Suggest driver owners from the leadership team's seat assignments. Each driver should be owned by the person whose seat most closely relates to that financial lever.
+
+### Scorecard (Read)
+
+- **Direction:** Read
+- **What data:** `data/scorecard/metrics.md`
+- **Purpose:** Cross-reference existing scorecard metrics with the 8 drivers. If a team already tracks "Weekly Revenue" on the scorecard, that overlaps with the Volume and Price drivers. Avoid duplicating metrics — reference existing ones.
+
+### Rocks (Related)
+
+- **Direction:** Related (suggest, don't write)
+- **What data:** N/A
+- **Purpose:** High-potential driver improvements can become quarterly Rocks. After assessment, suggest the user create Rocks for their top priorities via `ceos-rocks`.
+
+### IDS (Related)
+
+- **Direction:** Related (suggest, don't write)
+- **What data:** N/A
+- **Purpose:** Stalling or regressing drivers may need root-cause investigation. Suggest creating Issues via `ceos-ids` for drivers that aren't improving despite being prioritized.
+
+**Write Principle:** Only `ceos-cashflow` writes to `data/cashflow/`. Other skills may reference cash flow assessments for financial context.

--- a/skills/ceos-lma/SKILL.md
+++ b/skills/ceos-lma/SKILL.md
@@ -1,0 +1,489 @@
+---
+name: ceos-lma
+description: Use when assessing leadership and management effectiveness using the LMA framework
+file-access: [data/lma/, templates/lma-assessment.md, data/accountability.md, data/people/, data/clarity/, data/meetings/l10/, data/conversations/]
+tools-used: [Read, Write, Glob]
+---
+
+# ceos-lma
+
+Assess leadership and management effectiveness using the LMA (Leadership + Management = Accountability) framework — EOS Toolbox tool #11. Walk a manager through rating themselves on 5 Leadership Practices and 5 Management Practices, calculate scores, flag areas needing attention, and optionally gather 360-degree feedback from direct reports.
+
+**Not for:** Evaluating whether someone is a fit for their seat (use `ceos-people`), defining organizational structure (use `ceos-accountability`), or running quarterly conversations (use `ceos-quarterly`). LMA assesses *whether* you're practicing leadership and management habits, not *whether* you're the right person for the role.
+
+## When to Use
+
+- "Run LMA assessment" or "LMA checklist" or "LMA for [person]"
+- "How am I doing as a manager?" or "how am I doing as a leader?"
+- "Leadership assessment" or "management assessment"
+- "Am I creating accountability?" or "am I holding my team accountable?"
+- "LMA review" or "show LMA scores" or "team LMA summary"
+- "360 feedback for [person]" or "get feedback from my team"
+- "Run LMA" or "leadership and management check"
+
+## Context
+
+### Finding the CEOS Repository
+
+Search upward from the current directory for the `.ceos` marker file. This file marks the root of the CEOS repository.
+
+If `.ceos` is not found, stop and tell the user: "Not in a CEOS repository. Clone your CEOS repo and run setup.sh first."
+
+**Sync before use:** Once you find the CEOS root, run `git -C <ceos_root> pull --ff-only --quiet 2>/dev/null` to get the latest data from teammates. If it fails (conflict or offline), continue silently with local data.
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `data/lma/` | LMA assessment files (one per person) |
+| `templates/lma-assessment.md` | Template for new LMA assessments |
+| `data/accountability.md` | Source of management relationships and seat info (read-only — use ceos-accountability to modify) |
+| `data/people/` | People Analyzer evaluations (read-only — reference for context) |
+| `data/clarity/` | Clarity Break records (read-only — informs Leadership Practice #5) |
+| `data/meetings/l10/` | L10 meeting notes (read-only — informs Management Practice #3) |
+| `data/conversations/` | Quarterly conversation records (read-only — informs Management Practice #4) |
+
+### LMA File Format
+
+Each person has a markdown file at `data/lma/firstname-lastname.md` with YAML frontmatter:
+
+```yaml
+person: "Brad Feld"
+seat: "Visionary"
+date: "2026-02-15"
+status: active            # active | reviewed | stale
+leadership_score: 4.2
+management_score: 3.8
+overall_score: 4.0
+leadership_practices:
+  clear_direction: 5
+  necessary_tools: 4
+  letting_go: 4
+  greater_good: 5
+  clarity_breaks: 3
+management_practices:
+  clear_expectations: 4
+  communicating_well: 4
+  meeting_pulse: 3
+  quarterly_conversations: 4
+  rewarding_recognizing: 4
+feedback: []
+last_assessed: "2026-02-15"
+```
+
+**File naming:** `firstname-lastname.md` — lowercase, hyphenated. Person-centric (survives role changes).
+
+### Status Values
+
+| Status | Meaning | When |
+|--------|---------|------|
+| `active` | Current assessment, may need development actions | After initial assessment or re-assessment |
+| `reviewed` | Assessment reviewed, development plan updated | After a Review session |
+| `stale` | Assessment is > 120 days old | Flagged automatically by Review mode |
+
+### The 10 Practices
+
+#### Leadership Practices
+
+| # | Practice | Description | Data Source |
+|---|----------|-------------|-------------|
+| 1 | Giving clear direction | Setting vision, priorities, and expectations so people know where they're going | Self-assessment |
+| 2 | Providing the necessary tools | Ensuring people have what they need — training, resources, systems, authority | Self-assessment |
+| 3 | Letting go of the vine | Empowering others instead of micromanaging; trusting the team to execute | Self-assessment |
+| 4 | Acting with the greater good in mind | Making decisions for the organization's benefit, not personal interest | Self-assessment |
+| 5 | Taking Clarity Breaks | Stepping away to think strategically — "work ON the business, not IN it" | `data/clarity/` frequency |
+
+#### Management Practices
+
+| # | Practice | Description | Data Source |
+|---|----------|-------------|-------------|
+| 1 | Keeping expectations clear | Each direct report knows their seat, roles, Rocks, and measurables | Self-assessment |
+| 2 | Communicating well | Open, honest, two-way communication with the team | Self-assessment |
+| 3 | Maintaining the right meeting pulse | Running consistent, productive weekly meetings (L10s) | `data/meetings/l10/` regularity |
+| 4 | Having quarterly conversations | Formal quarterly check-ins with each direct report | `data/conversations/` frequency |
+| 5 | Rewarding and recognizing | Acknowledging great work and addressing underperformance | Self-assessment |
+
+### Rating Scale
+
+| Rating | Meaning |
+|--------|---------|
+| 1 | Never / Not at all |
+| 2 | Rarely |
+| 3 | Sometimes |
+| 4 | Usually |
+| 5 | Consistently |
+
+Scores below 3 indicate a practice that needs focused development.
+
+## Process
+
+### Mode: Assess
+
+Use when running an LMA self-assessment for a specific person. Recommended quarterly — ideally before Quarterly Planning sessions.
+
+#### Step 1: Identify the Person
+
+Ask for the person's name. Check if `data/lma/firstname-lastname.md` already exists.
+
+- **Exists:** Read the file, show previous scores: "You have an existing LMA assessment from [date] (Leadership: [X], Management: [Y], Overall: [Z]). Re-assess (start fresh scores) or update (revise notes only)?"
+- **New person:** Will create from `templates/lma-assessment.md`
+
+#### Step 2: Pull Context from Accountability Chart
+
+Read `data/accountability.md` to find the person's seat(s) and identify their direct reports.
+
+- **Has a seat:** Display: "[Person] holds the [Seat] seat with [N] direct reports."
+- **No seat found:** Warn: "[Person] has no seat defined in the Accountability Chart. LMA requires a management/leadership context. Add them via `ceos-accountability`, or proceed with manual context."
+
+#### Step 3: Gather Cross-Skill Context
+
+Read data from related skills to provide evidence-based context for specific practices:
+
+**Clarity Breaks (Leadership Practice #5):**
+- Read `data/clarity/` via Glob. Count files from the last 90 days.
+- Display: "[N] Clarity Breaks in the last 90 days" or "No Clarity Break records found. Consider running `ceos-clarity` to establish Clarity Break habits."
+
+**L10 Meeting Pulse (Management Practice #3):**
+- Read `data/meetings/l10/` via Glob. Check meeting frequency over the last 8 weeks.
+- Display: "[N] L10 meetings in the last 8 weeks ([frequency])" or "No L10 meeting records found. Consider running `ceos-l10` to establish meeting pulse."
+
+**Quarterly Conversations (Management Practice #4):**
+- Read `data/conversations/` via Glob. Check for conversations in the current and previous quarter.
+- Display: "[N] quarterly conversations recorded" or "No quarterly conversation records found."
+
+Show context summary before rating:
+
+```
+Cross-Skill Context for [Person]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Clarity Breaks (last 90 days): [N] sessions
+  L10 Meeting Pulse (last 8 weeks): [N]/8 weeks
+  Quarterly Conversations (current + prev quarter): [N] conversations
+```
+
+#### Step 4: Rate Leadership Practices
+
+Present each of the 5 Leadership Practices one at a time with its description and any relevant context data. Collect a 1-5 rating for each.
+
+For Practice #5 (Clarity Breaks), include the context data: "Your records show [N] Clarity Breaks in the last 90 days."
+
+After all 5 are rated, calculate Leadership Score as the average (one decimal place).
+
+```
+Leadership Practices — [Person]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+| # | Practice | Rating | Notes |
+|---|----------|--------|-------|
+| 1 | Giving clear direction | [1-5] | [user notes] |
+| 2 | Providing the necessary tools | [1-5] | |
+| 3 | Letting go of the vine | [1-5] | |
+| 4 | Acting with the greater good in mind | [1-5] | |
+| 5 | Taking Clarity Breaks | [1-5] | [N] breaks in 90 days |
+
+Leadership Score: [X.X] / 5.0
+```
+
+#### Step 5: Rate Management Practices
+
+Present each of the 5 Management Practices with description and relevant context data. Collect a 1-5 rating for each.
+
+For Practice #3 (Meeting Pulse), include: "Records show [N]/8 L10 meetings in the last 8 weeks."
+For Practice #4 (Quarterly Conversations), include: "[N] quarterly conversations recorded."
+
+Calculate Management Score as the average (one decimal place).
+
+```
+Management Practices — [Person]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+| # | Practice | Rating | Notes |
+|---|----------|--------|-------|
+| 1 | Keeping expectations clear | [1-5] | |
+| 2 | Communicating well | [1-5] | |
+| 3 | Maintaining the right meeting pulse | [1-5] | [N]/8 L10s |
+| 4 | Having quarterly conversations | [1-5] | [N] conversations |
+| 5 | Rewarding and recognizing | [1-5] | |
+
+Management Score: [X.X] / 5.0
+```
+
+#### Step 6: Calculate LMA Score
+
+Overall LMA Score = average of Leadership Score and Management Score (one decimal place).
+
+```
+LMA Score — [Person]
+━━━━━━━━━━━━━━━━━━━━
+
+  Leadership:  [X.X] / 5.0
+  Management:  [X.X] / 5.0
+  ─────────────────────────
+  Overall LMA: [X.X] / 5.0
+
+  Leadership + Management = Accountability
+```
+
+#### Step 7: Flag Practices Below 3
+
+List any practices scoring below 3 with suggested development actions:
+
+```
+Flagged Practices (Below 3)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+⚠️ [Practice Name] — rated [N]/5
+   Suggested: [specific, actionable development suggestion]
+
+⚠️ [Practice Name] — rated [N]/5
+   Suggested: [specific suggestion]
+```
+
+If no practices are below 3: "No practices flagged — all rated 3 or above."
+
+#### Step 8: Save the File
+
+Show the complete file before writing. Ask: "Save this LMA assessment?"
+
+Write to `data/lma/firstname-lastname.md` using the template. Update:
+- YAML frontmatter: all scores, practice ratings, date, status
+- Markdown body: populate practice tables with ratings and notes
+- Assessment History: add dated entry
+
+If re-assessing, preserve existing Assessment History entries and add a new one.
+
+---
+
+### Mode: Review
+
+Use when reviewing LMA results across all managers or for checking team-wide patterns.
+
+#### Step 1: Read All LMA Files
+
+Read all files from `data/lma/` via `Glob("data/lma/*.md")`. Parse YAML frontmatter.
+
+If no files exist: "No LMA assessments found. Run an Assess for your first team member."
+
+#### Step 2: Display Summary Table
+
+```
+LMA Review — Team Overview
+━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+| Name | Seat | Last Assessed | Leadership | Management | Overall LMA | Flag |
+|------|------|--------------|------------|------------|-------------|------|
+| Brad Feld | Visionary | 2026-02-15 | 4.2 | 3.8 | 4.0 | |
+| Sarah Chen | Integrator | 2026-01-10 | 3.6 | 4.4 | 4.0 | |
+| Mike Torres | VP Sales | 2025-09-15 | 3.0 | 2.8 | 2.9 | ⚠️ Mgmt |
+
+Team averages:
+  Leadership: [X.X]
+  Management: [X.X]
+  Overall LMA: [X.X]
+```
+
+#### Step 3: Identify Team-Wide Patterns
+
+Aggregate practice scores across all managers. Find the lowest-scoring practices:
+
+```
+Lowest-Scoring Practices (Team Average)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+| Practice | Type | Team Avg | Below 3 Count |
+|----------|------|---------|---------------|
+| Taking Clarity Breaks | Leadership | 2.5 | 2/3 managers |
+| Maintaining meeting pulse | Management | 3.0 | 1/3 managers |
+```
+
+#### Step 4: Flag Stale Assessments
+
+Check `last_assessed` date for each person. If > 120 days ago:
+
+"📅 [Person]'s LMA assessment is [N] days old. Consider re-running before the next Quarterly Planning session."
+
+#### Step 5: Show Trends
+
+If a person has multiple assessment history entries (from re-assessments), show the trend:
+
+```
+LMA Trend — [Person]
+━━━━━━━━━━━━━━━━━━━━
+
+| Date | Leadership | Management | Overall | Direction |
+|------|-----------|------------|---------|-----------|
+| 2025-11-01 | 3.4 | 3.2 | 3.3 | |
+| 2026-02-15 | 4.2 | 3.8 | 4.0 | ↑ Improving |
+```
+
+#### Step 6: Drill Down
+
+Ask: "Want to view details for a specific person, or run a new Assess?"
+
+---
+
+### Mode: 360
+
+Use when gathering feedback from direct reports to compare against a manager's self-assessment. This creates a gap analysis between self-perception and team perception.
+
+#### Step 1: Identify the Manager
+
+Ask for the manager's name. Read `data/lma/firstname-lastname.md`.
+
+- **Has self-assessment:** Load it, show current self-ratings.
+- **No self-assessment:** "No LMA self-assessment found for [person]. Run an Assess first — 360 feedback requires a self-assessment to compare against."
+
+#### Step 2: Identify Direct Reports
+
+Read `data/accountability.md` to find people who report to this manager.
+
+- **Has direct reports:** Display the list: "[Person] manages: [Name 1], [Name 2], [Name 3]"
+- **No direct reports found:** "360 mode requires direct reports. [Person] has none listed in the Accountability Chart. Use `ceos-accountability` to update the org chart, or name respondents manually."
+
+Ask which direct reports will provide feedback (may be a subset).
+
+#### Step 3: Collect Feedback
+
+For each respondent, rate the manager on all 10 practices (1-5). Use the same rating scale:
+
+"[Respondent Name] is rating [Manager Name]'s leadership and management practices."
+
+Present all 10 practices and collect ratings. This can be done one respondent at a time — the feedback array is additive. Each session adds one respondent's feedback.
+
+Store each respondent's feedback in the `feedback` frontmatter array:
+
+```yaml
+feedback:
+  - name: "Sarah Chen"
+    relationship: "direct report"
+    ratings: [4, 3, 5, 4, 3, 4, 4, 3, 4, 3]  # 10 ratings in practice order
+    date: "2026-02-15"
+```
+
+The ratings array follows practice order: Leadership 1-5, then Management 1-5.
+
+#### Step 4: Compare Self vs Team
+
+After at least one respondent's feedback is collected, display the comparison:
+
+```
+360 Comparison — [Manager Name]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Leadership Practices:
+| # | Practice | Self | Team Avg | Gap |
+|---|----------|------|---------|-----|
+| 1 | Giving clear direction | 5 | 4.0 | -1.0 |
+| 2 | Providing the necessary tools | 4 | 3.5 | -0.5 |
+| 3 | Letting go of the vine | 4 | 4.5 | +0.5 |
+| 4 | Acting with the greater good | 5 | 4.5 | -0.5 |
+| 5 | Taking Clarity Breaks | 3 | 3.0 | 0.0 |
+
+Management Practices:
+| # | Practice | Self | Team Avg | Gap |
+|---|----------|------|---------|-----|
+| 1 | Keeping expectations clear | 4 | 3.0 | -1.0 |
+| 2 | Communicating well | 4 | 3.5 | -0.5 |
+| 3 | Maintaining meeting pulse | 3 | 4.0 | +1.0 |
+| 4 | Having quarterly conversations | 4 | 3.0 | -1.0 ⚠️ |
+| 5 | Rewarding and recognizing | 4 | 2.5 | -1.5 ⚠️ |
+```
+
+#### Step 5: Flag Large Gaps
+
+Flag any practice where the absolute gap between self and team average is >= 2 points:
+
+```
+Significant Gaps (≥ 2 points)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+⚠️ [Practice Name] — Self: [X], Team: [Y] (gap: [Z])
+   This is worth discussing with the team. Large gaps indicate a
+   difference between how you perceive your effectiveness and how
+   your team experiences it.
+```
+
+If no gaps >= 2: "No significant gaps detected. Self-assessment and team feedback are generally aligned."
+
+#### Step 6: Save Updated File
+
+Show the complete updated file before writing. Ask: "Save this 360 feedback?"
+
+Update:
+- YAML frontmatter: add respondent to `feedback` array
+- Markdown body: update 360 Feedback table with respondent's data
+- Assessment History: add dated entry for 360 feedback collection
+
+## Output Format
+
+**Assess:** Practice rating tables (Leadership and Management), calculated scores, flagged practices below 3, and complete file shown before save.
+
+**Review:** Summary table with all managers, Leadership/Management/Overall scores, stale flags, team-wide practice patterns, and trends if multiple assessments exist.
+
+**360:** Side-by-side comparison table (Self vs Team Average vs Gap) for all 10 practices. Flagged gaps >= 2 points. Complete file shown before save.
+
+## Guardrails
+
+- **Always show the complete file before writing.** Never modify an LMA file without showing the change and getting approval.
+- **Validate ratings are 1-5.** Reject values outside this range with: "Ratings must be between 1 (Never) and 5 (Consistently)."
+- **Don't auto-invoke other skills.** When LMA results suggest running a Clarity Break or scheduling a quarterly conversation, mention the option but let the user decide. Say "Would you like to start a Clarity Break?" rather than doing it automatically.
+- **Don't confuse with People Analyzer.** LMA is a self-assessment of leadership/management effectiveness. People Analyzer (`ceos-people`) evaluates whether someone is the right person in the right seat. If the user seems to be evaluating a person's fit, suggest `ceos-people` instead.
+- **360 requires existing self-assessment.** Don't allow 360 feedback without a self-assessment to compare against. The comparison is the value.
+- **Sensitive data warning.** On first use in a session, remind the user: "LMA assessments contain information about leadership effectiveness. This repo should be private."
+- **Respect the quarterly cadence.** Suggest running LMA before Quarterly Planning sessions. Flag assessments > 120 days old. But don't nag — once per session is enough.
+- **One rating per practice.** Don't allow split ratings (e.g., "3.5"). Use whole numbers 1-5 only.
+- **Cross-skill data is context, not deterministic.** Low Clarity Break count doesn't automatically mean a low Leadership #5 rating. Present the data and let the user decide their rating.
+
+## Integration Notes
+
+### Accountability Chart (ceos-accountability)
+
+- **Direction:** Read
+- **What data:** `data/accountability.md` — seat names, owners, and reporting relationships
+- **Purpose:** Identifies who the manager is, what seat they hold, and who their direct reports are. Essential for both Assess (context) and 360 (respondent identification).
+
+### People Analyzer (ceos-people)
+
+- **Direction:** Read
+- **What data:** `data/people/firstname-lastname.md` — GWC assessment, current status
+- **Purpose:** Optional context during Assess. If a person is `below_bar`, LMA can help identify whether it's a leadership gap (not empowering them) or a management gap (unclear expectations).
+
+### Clarity Break (ceos-clarity)
+
+- **Direction:** Read
+- **What data:** `data/clarity/` — Clarity Break notes and frequency
+- **Purpose:** Provides evidence for Leadership Practice #5 (Taking Clarity Breaks). Count of recent breaks gives objective context for the self-rating.
+
+### L10 Meetings (ceos-l10)
+
+- **Direction:** Read
+- **What data:** `data/meetings/l10/` — L10 meeting notes
+- **Purpose:** Provides evidence for Management Practice #3 (Maintaining the right meeting pulse). Meeting frequency and regularity give objective context.
+
+### Quarterly Conversations (ceos-quarterly)
+
+- **Direction:** Read
+- **What data:** `data/conversations/` — Quarterly conversation records
+- **Purpose:** Provides evidence for Management Practice #4 (Having quarterly conversations). Conversation frequency gives objective context.
+
+### Quarterly Planning (ceos-quarterly-planning)
+
+- **Direction:** Related
+- **What data:** No direct data access
+- **Purpose:** LMA is ideally run before Quarterly Planning sessions. Leadership and management effectiveness directly impacts Rock execution and team accountability.
+
+### Annual Planning (ceos-annual)
+
+- **Direction:** Related
+- **What data:** No direct data access
+- **Purpose:** Annual planning is a natural time to re-assess LMA. Leaders reassess their effectiveness as they plan the new year.
+
+### Delegate and Elevate (ceos-delegate)
+
+- **Direction:** Related
+- **What data:** No direct data access
+- **Purpose:** Related development tool. LMA assesses *how* you lead and manage. Delegate and Elevate assesses *what work* you should focus on. Both serve leadership development.
+
+### Write Principle
+
+**Only `ceos-lma` writes to `data/lma/`.** Other skills may reference LMA assessments for leadership development context, but do not modify them.

--- a/skills/ceos-trust/SKILL.md
+++ b/skills/ceos-trust/SKILL.md
@@ -1,0 +1,604 @@
+---
+name: ceos-trust
+description: Use when building vulnerability-based trust through quarterly team exercises from the EOS Trust Builders toolbox
+file-access: [data/trust/, templates/trust-exercise.md, data/accountability.md, data/checkups/]
+tools-used: [Read, Write, Glob]
+---
+
+# ceos-trust
+
+Facilitate the 10 Trust Builder exercises from the EOS Toolbox, progressing from low to high vulnerability. Acts as a facilitation guide — providing instructions, timing, debrief questions, and recording outcomes — rather than trying to replicate exercises digitally. Teams typically do one exercise per quarter, building deeper trust over time. Drawn from Patrick Lencioni's "Five Dysfunctions of a Team" framework.
+
+**Not for:** People evaluation (use `ceos-people`), organizational health assessment (use `ceos-checkup`), or performance conversations (use `ceos-quarterly`). The Trust Builders are team-level exercises focused on vulnerability-based trust, not individual assessment.
+
+## When to Use
+
+- "Build team trust" or "trust building exercise"
+- "Run the next trust exercise" or "facilitate trust builders"
+- "What trust exercise is next?" or "trust exercise schedule"
+- "Show trust exercise history" or "review trust progression"
+- "Personal histories exercise" or any specific exercise name
+- "How is our team trust?" or "trust level check"
+- "Quarterly trust exercise" or "team bonding exercise"
+- Any discussion about vulnerability-based trust, team bonding, or the EOS Trust Builders
+
+## Context
+
+### Finding the CEOS Repository
+
+Search upward from the current directory for the `.ceos` marker file. This file marks the root of the CEOS repository.
+
+If `.ceos` is not found, stop and tell the user: "Not in a CEOS repository. Clone your CEOS repo and run setup.sh first."
+
+**Sync before use:** Once you find the CEOS root, run `git -C <ceos_root> pull --ff-only --quiet 2>/dev/null` to get the latest data from teammates. If it fails (conflict or offline), continue silently with local data.
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `data/trust/` | Exercise records — one file per completed exercise |
+| `templates/trust-exercise.md` | Template for recording exercise outcomes |
+| `data/accountability.md` | Team composition for participant suggestions (read-only — use ceos-accountability to modify) |
+| `data/checkups/` | Organizational Checkup scores for trust cross-reference (read-only — use ceos-checkup to modify) |
+
+### The 10 Exercises
+
+| # | Exercise | Vulnerability | Time Box | Description |
+|---|----------|--------------|----------|-------------|
+| 1 | Personal Histories | Low | 30-45 min | Each team member shares personal background (hometown, family, first job, hobbies) |
+| 2 | DISC/Kolbe Profiles | Low | 45-60 min | Share and discuss personality/working style assessment results |
+| 3 | Lifeline Exercise | Medium | 45-60 min | Map significant life events on a timeline, share with the team |
+| 4 | One Thing | Medium | 20-30 min | Each person shares one thing the team doesn't know about them |
+| 5 | Feedback Round | Medium | 45-60 min | Structured positive and constructive feedback for each team member |
+| 6 | Strengths Spotlight | Medium | 30-45 min | Each person identifies their top strengths, team validates and adds |
+| 7 | Conflict Norms | Medium-High | 45-60 min | Establish how the team will handle disagreement and conflict |
+| 8 | Accountability Partners | Medium-High | 30-45 min | Pair up for mutual accountability check-ins between meetings |
+| 9 | Team Effectiveness Debrief | High | 60-90 min | Rate and discuss how the team works together as a unit |
+| 10 | Vulnerability Circle | High | 30-60 min | Share a current struggle, fear, or area where you need help |
+
+### Vulnerability Levels
+
+| Level | Exercises | What It Means |
+|-------|-----------|---------------|
+| Low | 1-2 | Safe sharing — factual information, low personal risk |
+| Medium | 3-6 | Personal sharing with moderate risk — life events, feedback, strengths |
+| Medium-High | 7-8 | Navigating conflict and accountability — requires existing trust |
+| High | 9-10 | Deep vulnerability — honest assessment of team and personal struggles |
+
+### Exercise Record Format
+
+Each completed exercise is a markdown file at `data/trust/YYYY-MM-DD-exercise-slug.md` with YAML frontmatter:
+
+```yaml
+date: "2026-02-16"
+exercise_number: 1
+exercise_name: "Personal Histories"
+participants: ["Brad Feld", "Daniel"]
+facilitator: "Brad Feld"
+duration_minutes: 35
+vulnerability_level: low
+status: complete
+```
+
+**File naming:** `YYYY-MM-DD-exercise-slug.md` — date prefix for chronological ordering, exercise slug identifies the type.
+
+### Exercise Slug Reference
+
+| # | Exercise | Slug |
+|---|----------|------|
+| 1 | Personal Histories | `personal-histories` |
+| 2 | DISC/Kolbe Profiles | `disc-kolbe-profiles` |
+| 3 | Lifeline Exercise | `lifeline-exercise` |
+| 4 | One Thing | `one-thing` |
+| 5 | Feedback Round | `feedback-round` |
+| 6 | Strengths Spotlight | `strengths-spotlight` |
+| 7 | Conflict Norms | `conflict-norms` |
+| 8 | Accountability Partners | `accountability-partners` |
+| 9 | Team Effectiveness Debrief | `team-effectiveness-debrief` |
+| 10 | Vulnerability Circle | `vulnerability-circle` |
+
+## Process
+
+### Mode: Facilitate
+
+Use when guiding the team through the next Trust Builder exercise. This is the primary mode — one exercise per session.
+
+#### Step 1: Determine Which Exercise
+
+Read all files from `data/trust/` via `Glob("data/trust/*.md")`. Parse YAML frontmatter to find completed exercises by `exercise_number`.
+
+Determine the next exercise in sequence (lowest number not yet completed).
+
+- **No exercises completed:** Start with #1 Personal Histories.
+- **Some completed:** Recommend the next in sequence.
+- **All 10 completed:** "All 10 Trust Builder exercises are complete! Consider starting Cycle 2 — repeating exercises builds deeper trust each time. Recommend starting again with #1 Personal Histories."
+
+Display the recommendation:
+
+```
+Next Trust Builder: #N [Name]
+Vulnerability level: [low/medium/high]
+Time box: [N-N] minutes
+Last exercise: #[N-1] [Name] on [date]
+
+Ready to facilitate?
+```
+
+#### Step 2: Check Readiness
+
+**For medium or higher vulnerability exercises (3+):**
+"This is a [level]-vulnerability exercise. Ensure the team has completed the earlier exercises and the environment feels psychologically safe."
+
+**For exercise #2 (DISC/Kolbe Profiles):**
+"Note: Participants should have completed their DISC and/or Kolbe assessments before this exercise. Has everyone taken their assessments?"
+
+**For exercise #5 (Feedback Round):**
+"Note: This exercise involves giving and receiving direct feedback. Remind the team that feedback should be specific, actionable, and delivered with positive intent."
+
+**For exercise #7+ (Medium-High and High):**
+"This exercise requires a foundation of trust from earlier exercises. If the team hasn't built that foundation, consider revisiting exercises 1-6 first."
+
+#### Step 3: Read Participants
+
+Read `data/accountability.md` to identify leadership team members. Suggest them as participants.
+
+"Who is participating? (Default: leadership team from Accountability Chart)"
+
+Allow the user to confirm or modify the participant list.
+
+#### Step 4: Provide Facilitation Guide
+
+Display the exercise-specific facilitation guide based on the exercise number. Each exercise follows this structure:
+
+**Purpose → Setup → Steps → Time Management → Debrief Questions**
+
+---
+
+**Exercise 1: Personal Histories**
+
+*Purpose:* Break down barriers by sharing personal backgrounds. This is the foundation — it humanizes teammates beyond their work roles.
+
+*Setup:* Gather the team in a comfortable setting. No notes needed. Go around the table.
+
+*Steps:*
+1. Each person shares (3-5 minutes per person):
+   - Where did you grow up?
+   - How many siblings do you have?
+   - What was your first job?
+   - What's a unique hobby or interest?
+   - What's something most people don't know about you?
+2. After each person shares, allow brief reactions (no extended discussion)
+3. Complete the full round before moving to debrief
+
+*Time Management:* 3-5 min per person + 10 min debrief. For a team of 6: ~40 minutes total.
+
+*Debrief Questions:*
+1. What surprised you about someone's background?
+2. Did you discover something in common with a teammate?
+3. How does knowing this personal context change how you might work together?
+
+---
+
+**Exercise 2: DISC/Kolbe Profiles**
+
+*Purpose:* Understand each other's working styles to improve communication and reduce friction.
+
+*Setup:* All participants must have completed their DISC and/or Kolbe assessments beforehand. Print or display results.
+
+*Steps:*
+1. Each person shares their profile (3-5 minutes):
+   - Their dominant DISC style (D, I, S, or C)
+   - Their Kolbe MO (if available)
+   - "Here's what this means about how I work best..."
+   - "Here's what might frustrate me or slow me down..."
+2. After all have shared, discuss as a team:
+   - Where do profiles complement each other?
+   - Where might profiles clash?
+   - What accommodations could help?
+
+*Time Management:* 5 min per person + 15-20 min group discussion.
+
+*Debrief Questions:*
+1. Which profile differences explain past friction?
+2. How can we use this knowledge to communicate better?
+3. What's one thing you'll do differently knowing your teammates' styles?
+
+---
+
+**Exercise 3: Lifeline Exercise**
+
+*Purpose:* Build deeper understanding by sharing the significant events that shaped who you are.
+
+*Setup:* Give each person a blank piece of paper. Draw a horizontal line (the lifeline) from birth to present. Mark significant events above the line (positive) and below the line (negative/challenging).
+
+*Steps:*
+1. Silent preparation (5-10 minutes): Each person maps their lifeline
+2. Each person presents their lifeline (5-8 minutes):
+   - Walk through the major events chronologically
+   - Explain why each event was significant
+   - Share how it shaped who you are today
+3. After each presentation, team members may ask one clarifying question (optional)
+4. No judgment, no advice — just listening
+
+*Time Management:* 10 min prep + 8 min per person + 10 min debrief.
+
+*Debrief Questions:*
+1. What common themes did you notice across lifelines?
+2. How does understanding someone's life journey affect your empathy for them?
+3. What did it feel like to share? What did it feel like to listen?
+
+---
+
+**Exercise 4: One Thing**
+
+*Purpose:* A quick exercise to build on existing trust by sharing something new and personal.
+
+*Setup:* Simple round-table format. No preparation needed.
+
+*Steps:*
+1. Each person shares one thing the team doesn't know about them (2-3 minutes each)
+   - Can be personal, professional, quirky, or meaningful
+   - The "one thing" should feel slightly vulnerable — beyond surface-level facts
+2. Brief reactions allowed after each share
+3. Keep it light but genuine
+
+*Time Management:* 3 min per person + 5 min debrief.
+
+*Debrief Questions:*
+1. What was the hardest part about choosing your "one thing"?
+2. Did anyone's share change your perception of them?
+3. What does this exercise tell you about the team's comfort level?
+
+---
+
+**Exercise 5: Feedback Round**
+
+*Purpose:* Practice giving and receiving honest feedback in a structured, safe format.
+
+*Setup:* Each person will give feedback to every other team member. Prepare by thinking about one strength and one area for growth per person.
+
+*Steps:*
+1. Go person by person — one person is the "focus" at a time
+2. Each team member shares for the focus person:
+   - "Your greatest strength that helps the team is..."
+   - "One area where I think you could grow is..."
+3. The focus person listens without responding (except to say "thank you")
+4. After all feedback is given, the focus person may ask ONE clarifying question
+5. Move to the next focus person
+
+*Time Management:* For a team of N, each round takes ~3 min × (N-1) people giving feedback + 2 min transition. Total: roughly 5-8 min per focus person.
+
+*Debrief Questions:*
+1. What feedback surprised you the most?
+2. Was it harder to give or receive feedback?
+3. What's one piece of feedback you want to act on this quarter?
+4. How can we make giving feedback a more regular practice?
+
+---
+
+**Exercise 6: Strengths Spotlight**
+
+*Purpose:* Reinforce what each person does best and ensure the team leverages individual strengths.
+
+*Setup:* Each person prepares a list of their top 3-5 personal strengths before the session.
+
+*Steps:*
+1. Each person presents their self-identified strengths (2-3 minutes)
+2. Team members respond:
+   - Validate: "I agree — I see that strength when you..."
+   - Add: "I'd also add [strength] because..."
+   - Reframe: "I'd describe it slightly differently as..."
+3. Record the final agreed-upon strengths list for each person
+
+*Time Management:* 5-7 min per person + 10 min debrief.
+
+*Debrief Questions:*
+1. Were your self-identified strengths aligned with how the team sees you?
+2. What strength did a teammate identify that you hadn't considered?
+3. How can we better leverage each person's strengths in our daily work?
+
+---
+
+**Exercise 7: Conflict Norms**
+
+*Purpose:* Establish explicit agreements for how the team will handle disagreement, preventing unhealthy conflict patterns.
+
+*Setup:* Whiteboard or shared document. This is a group discussion, not individual sharing.
+
+*Steps:*
+1. Discuss current conflict patterns (10-15 minutes):
+   - "When we disagree, what typically happens?"
+   - "What works well about how we handle conflict?"
+   - "What doesn't work?"
+2. Brainstorm conflict norms (15-20 minutes):
+   - How do we raise disagreements? (In the room, not in the hallway)
+   - How do we ensure everyone speaks? (Round-table before open discussion)
+   - How do we resolve impasses? (Leader decides after hearing all views)
+   - What's off-limits? (Personal attacks, relitigating decided issues)
+3. Agree on 5-7 specific norms (10-15 minutes)
+4. Write them down — these become the team's conflict agreement
+
+*Time Management:* 45-60 minutes for the full exercise.
+
+*Debrief Questions:*
+1. Which norm will be hardest for the team to follow?
+2. What will we do when someone breaks a norm?
+3. How will we revisit these norms to make sure they're working?
+
+---
+
+**Exercise 8: Accountability Partners**
+
+*Purpose:* Create peer-to-peer accountability relationships that supplement the formal meeting structure.
+
+*Setup:* Pair team members. Consider pairing people who don't work closely together or who have complementary strengths.
+
+*Steps:*
+1. Discuss the concept (5 minutes): Accountability partners check in between L10s to help each other stay on track with Rocks, To-Dos, and personal development
+2. Form pairs (5-10 minutes): Each pair commits to:
+   - A weekly 15-minute check-in (phone, video, or in-person)
+   - What they'll cover: Rock progress, To-Do completion, one personal goal
+   - How they'll hold each other accountable (direct, constructive)
+3. Each pair shares their plan with the team (2-3 minutes per pair)
+4. Set a review date (e.g., end of quarter) to assess whether the partnerships are working
+
+*Time Management:* 30-45 minutes total.
+
+*Debrief Questions:*
+1. What do you hope to get from your accountability partner?
+2. What makes you nervous about this level of accountability?
+3. How will you handle it if your partner isn't following through?
+
+---
+
+**Exercise 9: Team Effectiveness Debrief**
+
+*Purpose:* Honestly assess how the team functions as a unit — what's working, what isn't, and what needs to change.
+
+*Setup:* Each person independently rates the team on 5 dimensions (1-5 scale) before the session:
+1. Trust — Do we feel safe being vulnerable?
+2. Conflict — Do we engage in productive disagreement?
+3. Commitment — Do we align behind decisions?
+4. Accountability — Do we hold each other to standards?
+5. Results — Are we focused on collective outcomes?
+
+(These map to Lencioni's Five Dysfunctions pyramid.)
+
+*Steps:*
+1. Share individual ratings (go around, no discussion yet) — 10 minutes
+2. Identify the biggest gaps (where ratings diverge most) — 10 minutes
+3. Deep-dive on the lowest-scoring dimension:
+   - What specific behaviors drive the low score?
+   - What would a "5" look like?
+   - What's one thing we could change this quarter?
+4. Repeat for the second-lowest dimension if time allows
+5. Agree on 2-3 team commitments
+
+*Time Management:* 60-90 minutes. This is the most substantive exercise.
+
+*Debrief Questions:*
+1. Were you surprised by anyone else's ratings?
+2. Which dimension do you personally need to work on most?
+3. What's the single most important thing we can improve as a team?
+4. How will we measure whether we've improved by next quarter?
+
+---
+
+**Exercise 10: Vulnerability Circle**
+
+*Purpose:* The deepest trust exercise — each person shares a current struggle, fear, or area where they need support.
+
+*Setup:* This exercise requires strong existing trust. Ensure exercises 1-9 have been completed. Set the tone: "This is a safe space. What's shared here stays here. Our only job is to listen and support."
+
+*Steps:*
+1. Set ground rules (5 minutes):
+   - No fixing, no advice (unless asked)
+   - No judgment
+   - Confidentiality — nothing leaves this room
+   - It's OK to pass (but encouragement to try)
+2. Each person shares (5-8 minutes):
+   - "The thing I'm struggling with most right now is..."
+   - "What I'm most afraid of is..."
+   - "Where I need help from this team is..."
+3. After each share, the team responds:
+   - Brief acknowledgment: "Thank you for sharing that"
+   - One supportive statement (optional): "I relate because..." or "I want you to know..."
+4. Complete the full circle before debrief
+
+*Time Management:* 5-8 min per person + 15 min debrief. For a team of 6: ~50-60 minutes.
+
+*Debrief Questions:*
+1. How did it feel to share at this level?
+2. What did you learn about the team's capacity for support?
+3. How has our trust level changed from Exercise 1 to now?
+4. What do we want to commit to as a team going forward?
+
+---
+
+#### Step 5: Record Outcomes
+
+After the exercise is complete, ask the user for:
+
+1. **Key takeaways:** "What were the main insights or outcomes from this exercise?" (3-5 bullet points)
+2. **Facilitation notes:** "How did the exercise go? Any observations about the process?"
+3. **Debrief notes:** "How did the debrief discussion go?"
+4. **Follow-up actions:** "Any action items that came out of this?" (optional)
+5. **Duration:** "How long did the exercise take?"
+
+Create a new file from `templates/trust-exercise.md` at `data/trust/YYYY-MM-DD-exercise-slug.md`. Fill in all frontmatter fields and body sections.
+
+#### Step 6: Save
+
+Show the complete file before writing. Ask: "Save this trust exercise record?"
+
+After saving, display:
+
+```
+Exercise #N [Name] complete!
+
+Progression: N/10 exercises completed
+Next: #[N+1] [Name] ([vulnerability level])
+Recommended timing: Next quarter (~90 days)
+
+Trust exercises build on each other. The next exercise
+will go deeper — schedule it for your next quarterly session.
+```
+
+---
+
+### Mode: Schedule
+
+Use when checking which exercises have been completed, what's next, and whether the team is on cadence.
+
+#### Step 1: Load All Records
+
+Read all files from `data/trust/` via `Glob("data/trust/*.md")`. Parse YAML frontmatter.
+
+If no files exist: "No trust exercises recorded yet. Start with Exercise #1: Personal Histories using Facilitate mode."
+
+#### Step 2: Build Progression Table
+
+```
+Trust Builders — Progression
+━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+| # | Exercise | Level | Status | Date | Participants |
+|---|----------|-------|--------|------|-------------|
+| 1 | Personal Histories | Low | ✓ Done | 2026-01-15 | Brad, Daniel |
+| 2 | DISC/Kolbe Profiles | Low | ✓ Done | 2026-04-10 | Brad, Daniel |
+| 3 | Lifeline Exercise | Medium | → Next | — | — |
+| 4 | One Thing | Medium | Pending | — | — |
+| ... | ... | ... | ... | ... | ... |
+| 10 | Vulnerability Circle | High | Pending | — | — |
+
+Progress: 2/10 exercises (20%)
+██████░░░░░░░░░░░░░░░░░░ 20%
+```
+
+#### Step 3: Flag Staleness
+
+Calculate days since most recent exercise.
+
+- **> 120 days:** "⚠️ [N] days since last trust exercise. Recommended cadence is quarterly (~90 days). Consider scheduling the next exercise."
+- **90-120 days:** "The next trust exercise is due soon — last one was [N] days ago."
+- **< 90 days:** No flag.
+
+#### Step 4: Cross-Reference Checkup Trust Score
+
+Optionally read `data/checkups/` for the most recent organizational checkup. Look for Question 11 score (leadership trust question).
+
+- **Score < 3.0:** "📊 Checkup Question 11 (leadership trust) scored [X]/5. The Trust Builders exercises can help improve this. Consider prioritizing the next exercise."
+- **Score ≥ 3.0:** Mention the score but no urgent recommendation.
+
+If no checkup data exists, skip this step silently.
+
+---
+
+### Mode: Review
+
+Use when reviewing the history of trust exercises — dates, participants, key takeaways, and progression over time.
+
+#### Step 1: Load All Records
+
+Read all files from `data/trust/` via `Glob("data/trust/*.md")`. Parse YAML frontmatter.
+
+If no files exist: "No trust exercises recorded yet. Start with Exercise #1: Personal Histories using Facilitate mode."
+
+#### Step 2: Display History Table
+
+Show all completed exercises chronologically:
+
+```
+Trust Builders — Exercise History
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+| Date | # | Exercise | Level | Duration | Participants | Key Takeaway |
+|------|---|----------|-------|----------|-------------|-------------|
+| 2026-01-15 | 1 | Personal Histories | Low | 35 min | Brad, Daniel | Discovered shared background in... |
+| 2026-04-10 | 2 | DISC/Kolbe Profiles | Low | 50 min | Brad, Daniel | Brad is high-D, Daniel is high-I... |
+```
+
+#### Step 3: Show Progression Summary
+
+```
+Progression Summary:
+  Completed: N/10 exercises
+  Current cycle: 1 (exercises 1-10)
+  Exercises by vulnerability level:
+    Low (1-2): N completed
+    Medium (3-6): N completed
+    Medium-High (7-8): N completed
+    High (9-10): N completed
+  Avg time between exercises: [N] days
+  Total time invested: [N] minutes across [N] exercises
+```
+
+#### Step 4: Show Cycle Status
+
+If all 10 exercises are complete:
+
+```
+🎉 Cycle 1 Complete!
+
+All 10 Trust Builder exercises have been completed.
+Consider starting Cycle 2 — repeating exercises builds deeper trust.
+Many teams report that exercises hit differently the second time around,
+especially as the team evolves and new members join.
+```
+
+If the team has completed multiple cycles, show cycle-over-cycle comparison.
+
+#### Step 5: Drill Down
+
+Ask: "Want to view the full record for a specific exercise?"
+
+If yes, read and display the complete file for the requested exercise.
+
+## Output Format
+
+**Facilitate:** Exercise-specific facilitation guide with purpose, setup, steps, time management, and debrief questions. Outcome record shown before save. Post-exercise summary with next exercise recommendation.
+
+**Schedule:** Progression table showing all 10 exercises with completion status, staleness warnings, and checkup trust score cross-reference. Visual progress bar.
+
+**Review:** Chronological history table with dates, exercises, levels, durations, and key takeaways. Progression summary by vulnerability level. Cycle status.
+
+## Guardrails
+
+- **Always show the complete file before writing.** Never save an exercise record without displaying it and getting approval.
+- **Don't auto-invoke other skills.** When trust results suggest running a checkup or updating people evaluations, mention the option but let the user decide. Say "Would you like to run an organizational checkup?" rather than doing it automatically.
+- **Sensitive data warning.** On first use in a session, remind the user: "Trust exercise records contain personal sharing and vulnerability-based feedback. This repo should be private."
+- **Respect the vulnerability progression.** Do not recommend skipping ahead to high-vulnerability exercises if earlier exercises haven't been completed. If the team attempts exercise 7+ without completing 1-6, warn: "Exercises 7-10 require a foundation of trust from earlier exercises. Consider completing exercises [missing numbers] first."
+- **Facilitation guide, not digital exercise.** The skill provides instructions and records outcomes — the actual exercises happen in person or in a live meeting. Don't try to simulate the exercises by asking participants to type their responses.
+- **Don't pressure sharing.** The exercises involve vulnerability. If a participant wants to pass, that's acceptable. Note it in the record but don't push.
+- **One exercise per session.** Each facilitation session covers one exercise. Don't try to run multiple exercises in sequence — each needs time to land emotionally.
+- **Confidentiality reminder.** For exercises 7+ (medium-high and high vulnerability), remind the team: "What's shared in this exercise stays within the team."
+
+## Integration Notes
+
+### Accountability Chart (ceos-accountability)
+
+- **Direction:** Read
+- **What data:** `data/accountability.md` — seat names, owners, team members
+- **Purpose:** Identifies leadership team members for participant suggestions during Facilitate mode. The accountability chart defines who should be in the room for trust exercises.
+
+### Organizational Checkup (ceos-checkup)
+
+- **Direction:** Read
+- **What data:** `data/checkups/` — organizational health assessment scores
+- **Purpose:** Question 11 in the checkup measures leadership team trust. Low scores (< 3.0) suggest prioritizing Trust Builder exercises. Schedule mode cross-references the most recent checkup trust score.
+
+### Annual Planning (ceos-annual)
+
+- **Direction:** Related
+- **What data:** No direct data access
+- **Purpose:** Annual planning sessions often include a review of team trust and may trigger scheduling the next Trust Builder exercise. The trust exercise progression can inform annual planning discussions about team health.
+
+### Quarterly Planning (ceos-quarterly-planning)
+
+- **Direction:** Related
+- **What data:** No direct data access
+- **Purpose:** The quarterly cadence of trust exercises aligns naturally with quarterly planning. Review trust progression as part of the quarterly planning agenda. Schedule the next exercise if overdue.
+
+### Write Principle
+
+**Only `ceos-trust` writes to `data/trust/`.** Other skills may reference trust exercise data for team health context, but do not modify exercise records.

--- a/templates/assistance-daily.md
+++ b/templates/assistance-daily.md
@@ -1,0 +1,48 @@
+---
+date: "{{date}}"
+leader: "{{leader}}"
+assistant: "{{assistant}}"
+items_reviewed: 0
+items_handed_off: 0
+items_completed: 0
+duration_minutes: null
+---
+
+# Daily Standup — {{date}}
+
+**Leader:** {{leader}}
+**Assistant:** {{assistant}}
+
+---
+
+## Stack Review
+
+*Items reviewed from the stack during this meeting.*
+
+| # | Item | Urgency | Decision | Notes |
+|---|------|---------|----------|-------|
+| 1 | [Stack item title] | [today/this_week/whenever] | [hand_off/defer/done] | [Any context] |
+
+---
+
+## New Items Added
+
+*New items that came up during the meeting.*
+
+| # | Item | Urgency | Assigned To | Notes |
+|---|------|---------|-------------|-------|
+| 1 | [New item] | [today/this_week/whenever] | [Person] | [Context] |
+
+---
+
+## Action Items
+
+*Specific actions to complete before next daily standup.*
+
+- [ ] [Action item with owner]
+
+---
+
+## Meeting Notes
+
+[Any additional discussion, observations, or follow-up needed]

--- a/templates/assistance-stack.md
+++ b/templates/assistance-stack.md
@@ -1,0 +1,30 @@
+---
+id: "{{id}}"
+title: "{{title}}"
+from: "{{from}}"
+to: "{{to}}"
+urgency: pending          # today | this_week | whenever
+status: pending           # pending | handed_off | done
+created: "{{date}}"
+handed_off: null
+completed: null
+---
+
+# {{title}}
+
+**From:** {{from}}
+**To:** {{to}}
+**Urgency:** Pending
+**Created:** {{date}}
+
+## Details
+
+[Description of the task or item being delegated]
+
+## Notes
+
+[Any context, background, or special instructions]
+
+## Outcome
+
+[Filled in when status changes to done — what happened, any follow-up needed]

--- a/templates/cashflow-assessment.md
+++ b/templates/cashflow-assessment.md
@@ -1,0 +1,200 @@
+---
+date: "{{date}}"
+participants: "{{team_members}}"
+status: in_progress
+overall_summary: null
+drivers:
+  price:
+    current_state: null
+    potential: null
+    owner: null
+    baseline_metric: null
+    target_metric: null
+    priority_rank: null
+    notes: null
+  volume:
+    current_state: null
+    potential: null
+    owner: null
+    baseline_metric: null
+    target_metric: null
+    priority_rank: null
+    notes: null
+  cogs_margin:
+    current_state: null
+    potential: null
+    owner: null
+    baseline_metric: null
+    target_metric: null
+    priority_rank: null
+    notes: null
+  ar_days:
+    current_state: null
+    potential: null
+    owner: null
+    baseline_metric: null
+    target_metric: null
+    priority_rank: null
+    notes: null
+  ap_days:
+    current_state: null
+    potential: null
+    owner: null
+    baseline_metric: null
+    target_metric: null
+    priority_rank: null
+    notes: null
+  inventory_wip:
+    current_state: null
+    potential: null
+    owner: null
+    baseline_metric: null
+    target_metric: null
+    priority_rank: null
+    notes: null
+  opex:
+    current_state: null
+    potential: null
+    owner: null
+    baseline_metric: null
+    target_metric: null
+    priority_rank: null
+    notes: null
+  debt_structure:
+    current_state: null
+    potential: null
+    owner: null
+    baseline_metric: null
+    target_metric: null
+    priority_rank: null
+    notes: null
+---
+
+# Cash Flow Assessment — {{date}}
+
+**Participants:** {{team_members}}
+
+---
+
+## Driver Summary
+
+| # | Driver | Potential | Owner | Baseline | Target | Priority |
+|---|--------|-----------|-------|----------|--------|----------|
+| 1 | Price | | | | | |
+| 2 | Volume | | | | | |
+| 3 | COGS / Margin | | | | | |
+| 4 | A/R Days | | | | | |
+| 5 | A/P Days | | | | | |
+| 6 | Inventory / WIP | | | | | |
+| 7 | Operating Expenses | | | | | |
+| 8 | Debt Structure | | | | | |
+
+---
+
+## 1. Price
+
+**Current State:**
+> [How are prices set? When was the last price increase?]
+
+**Improvement Potential:** [high/medium/low/none]
+**Baseline:** [Current metric]
+**Target:** [Desired metric]
+**Owner:** [Name]
+
+---
+
+## 2. Volume
+
+**Current State:**
+> [Current sales volume and growth trajectory]
+
+**Improvement Potential:** [high/medium/low/none]
+**Baseline:** [Current metric]
+**Target:** [Desired metric]
+**Owner:** [Name]
+
+---
+
+## 3. COGS / Margin
+
+**Current State:**
+> [Current cost structure and gross margin]
+
+**Improvement Potential:** [high/medium/low/none]
+**Baseline:** [Current metric]
+**Target:** [Desired metric]
+**Owner:** [Name]
+
+---
+
+## 4. A/R Days
+
+**Current State:**
+> [Current days sales outstanding and collection process]
+
+**Improvement Potential:** [high/medium/low/none]
+**Baseline:** [Current metric]
+**Target:** [Desired metric]
+**Owner:** [Name]
+
+---
+
+## 5. A/P Days
+
+**Current State:**
+> [Current payment terms with vendors]
+
+**Improvement Potential:** [high/medium/low/none]
+**Baseline:** [Current metric]
+**Target:** [Desired metric]
+**Owner:** [Name]
+
+---
+
+## 6. Inventory / WIP
+
+**Current State:**
+> [Current inventory levels or work-in-progress backlog]
+
+**Improvement Potential:** [high/medium/low/none]
+**Baseline:** [Current metric]
+**Target:** [Desired metric]
+**Owner:** [Name]
+
+---
+
+## 7. Operating Expenses
+
+**Current State:**
+> [Major expense categories and trends]
+
+**Improvement Potential:** [high/medium/low/none]
+**Baseline:** [Current metric]
+**Target:** [Desired metric]
+**Owner:** [Name]
+
+---
+
+## 8. Debt Structure
+
+**Current State:**
+> [Current debt mix, terms, and cost of capital]
+
+**Improvement Potential:** [high/medium/low/none]
+**Baseline:** [Current metric]
+**Target:** [Desired metric]
+**Owner:** [Name]
+
+---
+
+## Action Plan
+
+| # | Driver | Action | Owner | Timeline | Status |
+|---|--------|--------|-------|----------|--------|
+| 1 | | | | | |
+
+---
+
+## Assessment Notes
+
+- {{date}}: Cash flow assessment conducted

--- a/templates/l10-meeting.md
+++ b/templates/l10-meeting.md
@@ -1,6 +1,6 @@
 ---
 date: "{{date}}"
-attendees: [{{team_members}}]
+attendees: "{{attendees}}"
 rating: null
 ---
 

--- a/templates/lma-assessment.md
+++ b/templates/lma-assessment.md
@@ -1,0 +1,102 @@
+---
+person: "{{person}}"
+seat: "{{seat}}"
+date: "{{date}}"
+status: active            # active | reviewed | stale
+leadership_score: null
+management_score: null
+overall_score: null
+leadership_practices:
+  clear_direction: null       # 1-5 or null
+  necessary_tools: null
+  letting_go: null
+  greater_good: null
+  clarity_breaks: null
+management_practices:
+  clear_expectations: null    # 1-5 or null
+  communicating_well: null
+  meeting_pulse: null
+  quarterly_conversations: null
+  rewarding_recognizing: null
+feedback: []                  # 360 feedback entries
+last_assessed: "{{date}}"
+---
+
+# {{person}} — LMA Assessment
+
+**Seat:** {{seat}}
+**Last Assessed:** {{date}}
+**Status:** Active
+
+---
+
+## Leadership Practices
+
+*5 practices that inspire people to follow you.*
+
+| # | Practice | Rating | Notes |
+|---|----------|--------|-------|
+| 1 | Giving clear direction | | |
+| 2 | Providing the necessary tools | | |
+| 3 | Letting go of the vine | | |
+| 4 | Acting with the greater good in mind | | |
+| 5 | Taking Clarity Breaks | | |
+
+**Leadership Score:** —
+
+---
+
+## Management Practices
+
+*5 practices that create systems of accountability.*
+
+| # | Practice | Rating | Notes |
+|---|----------|--------|-------|
+| 1 | Keeping expectations clear | | |
+| 2 | Communicating well | | |
+| 3 | Maintaining the right meeting pulse | | |
+| 4 | Having quarterly conversations | | |
+| 5 | Rewarding and recognizing | | |
+
+**Management Score:** —
+
+---
+
+## LMA Score
+
+**Leadership + Management = Accountability**
+
+| Component | Score |
+|-----------|-------|
+| Leadership | — |
+| Management | — |
+| **Overall LMA** | **—** |
+
+---
+
+## Flagged Practices
+
+*Practices scoring below 3 need attention.*
+
+*(None flagged yet)*
+
+---
+
+## 360 Feedback
+
+*Feedback from direct reports comparing self-assessment vs team perception.*
+
+| Respondent | Date | Leadership Avg | Management Avg | Overall Avg |
+|-----------|------|---------------|----------------|-------------|
+
+---
+
+## Development Plan
+
+- [ ] [Action item based on flagged practices]
+
+---
+
+## Assessment History
+
+- {{date}}: Initial LMA assessment conducted

--- a/templates/quarterly-quick.md
+++ b/templates/quarterly-quick.md
@@ -1,0 +1,58 @@
+---
+type: quick
+person: "[Full Name]"
+manager: "[Manager Name]"
+quarter: "{{quarter}}"
+date: "{{date}}"
+core_values_rating: null
+gwc_status: null
+rocks_completion_rate: null
+---
+
+# 5-5-5 Check-In — [Full Name]
+
+**Manager:** [Manager Name]
+**Quarter:** {{quarter}}
+**Date:** {{date}}
+
+---
+
+## Employee Speaks (5 min)
+
+*What does the employee want to share? Focus on Core Values, Rocks, and their Role (GWC).*
+
+**Core Values:** [How are they living the Core Values?]
+
+**Rocks:** [How are their Rocks going?]
+
+**Role (GWC):** [How do they feel about their seat — Get It, Want It, Capacity?]
+
+---
+
+## Manager Speaks (5 min)
+
+*What does the manager want to share? Focus on performance, wins, and concerns.*
+
+**Performance:** [How is the employee doing overall?]
+
+**Wins:** [What's going well? Recognize achievements.]
+
+**Concerns:** [Any issues to address?]
+
+---
+
+## Together (5 min)
+
+*Agree on next steps and commitments together.*
+
+**Next Steps:**
+- [Agreed action or commitment]
+
+**Commitments:**
+- [What each person will do before next check-in]
+
+---
+
+## Conversation History
+
+- {{date}}: 5-5-5 check-in conducted

--- a/templates/trust-exercise.md
+++ b/templates/trust-exercise.md
@@ -1,0 +1,52 @@
+---
+date: "{{date}}"
+exercise_number: null      # 1-10
+exercise_name: "{{exercise_name}}"
+participants: []            # List of team member names
+facilitator: "{{facilitator}}"
+duration_minutes: null
+vulnerability_level: "{{vulnerability_level}}"  # low | medium | high
+status: complete
+---
+
+# {{exercise_name}} — {{date}}
+
+**Exercise:** #{{exercise_number}} of 10
+**Vulnerability Level:** {{vulnerability_level}}
+**Facilitator:** {{facilitator}}
+**Participants:** {{participants}}
+**Duration:** {{duration_minutes}} minutes
+
+---
+
+## Setup
+
+[Pre-exercise preparation notes — what was needed before starting]
+
+---
+
+## Facilitation Notes
+
+[What happened during the exercise — observations about how it went]
+
+---
+
+## Key Takeaways
+
+[Team insights and outcomes — what emerged from the exercise]
+
+- [Takeaway 1]
+- [Takeaway 2]
+- [Takeaway 3]
+
+---
+
+## Debrief Notes
+
+[Post-exercise discussion — how the team reflected on the experience]
+
+---
+
+## Follow-Up Actions
+
+- [ ] [Action item with owner, if any]


### PR DESCRIPTION
## Summary
Additions-only sync of the private backlog (content authored Feb-Jul that never reached the public repo):
- **4 skills**: ceos-assistance, ceos-cashflow (The 8 Cash Flow Drivers), ceos-lma (Leadership+Management=Accountability), ceos-trust
- **7 templates**: assistance-daily, assistance-stack, cashflow-assessment, lma-assessment, quarterly-quick, trust-exercise, l10-meeting (update)
- **kit.yaml**: the Kit Contract v1 manifest (machine-readable kit identity + installer entry)

## What this deliberately does NOT do
- No deletions, no overwrites of community-contributed work (ceos-trends, ceos-calendar, l10 Transcript Mode, and all other both-sides-changed files are untouched — those reconcile in a follow-up reviewed merge).
- Computed three-way against the Feb 13 merge-base: only files changed EXCLUSIVELY on the private side are included.

## Context
First step of inverting the sync model: this public repo becomes canonical for all publishable content; the old one-way rsync --delete publish flow is retired (it would have destroyed contributor work).
