### PR TITLE
fix: actually exclude data/ — the comment claimed a rule that did not exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,17 @@
-# Company EOS data — committed in this private repo
-# (The public upstream repo at bradfeld/ceos excludes data/)
+# Company EOS data — NEVER commit this.
+#
+# Your accountability chart, scorecard, rocks, issues, and financials are
+# confidential. This repository is public, and so is every fork of it, so a
+# committed data/ directory is readable by anyone — and stays readable after you
+# delete it, because it remains in the commit history and in the shared fork
+# object store. If you have already committed data/, removing the file is not
+# enough; rewrite the history and rotate anything sensitive it revealed.
+#
+# The rule below is what enforces the exclusion. Before 2026-08-04 this section
+# was a comment ASSERTING that data/ was excluded, with no matching rule anywhere
+# in the file — wording inherited from the private upstream repo, where data/ is
+# deliberately tracked. An assertion is not a rule.
+data/
 
 # Session state (per-worktree, not shared)
 .claude-session/


### PR DESCRIPTION
## The bug

The first two lines of `.gitignore` stated that `data/` was excluded:

```
# Company EOS data — committed in this private repo
# (The public upstream repo at bradfeld/ceos excludes data/)
```

There was no `data/` rule anywhere in the file.

```
curl -s https://raw.githubusercontent.com/bradfeld/ceos/main/.gitignore \
  | grep -cE '^[[:space:]]*/?data/?[[:space:]]*$'
# -> 0
```

The wording was inherited from the private upstream repo, where `data/` is deliberately **tracked** — so the sentence was true there and false here. The only real exclusion is `publish.sh`'s copy allowlist, which lives in the private repo and therefore does not apply to anyone who forks or clones this one.

An EOS accountability chart, scorecard, and rocks are confidential by default. Anyone adopting this repo got a `.gitignore` that told them their data was protected and did not protect it.

## The fix

Adds the missing `data/` rule and replaces the assertion with an explanation — including that deleting an already-committed `data/` is **not** sufficient, since it survives in commit history and in the shared fork object store.

## Verification

```
git check-ignore -v data/vision.md
# -> .gitignore:14:data/	data/vision.md
```

`git status` no longer offers a `data/` file for staging. The audit's own detector now returns 1 instead of 0.

## Note for the private upstream

`IntensityMagic/ceos` tracks 35 files under `data/` on purpose, and must keep doing so. Its `.gitignore` is deliberately **not** changed to match — the two repos have opposite requirements, which is the root cause of this bug. Since CEO-50 retired the one-way `publish.sh --push` and made this repo canonical, watch that a private pull from upstream does not drag this `data/` rule into the private repo: existing tracked files would stay tracked, but a new one added via `git add -A` would be silently skipped.