### PR TITLE
fix: never publish the dashboard write token in plaintext

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,20 @@ Thumbs.db
 *.swo
 *~
 
+# Secrets. Nothing has leaked — no .env exists in any commit of this repo — but
+# this is a public repo with a dashboard build that reads GITHUB_WRITE_TOKEN and
+# DASHBOARD_PASSWORD from the environment, so a local .env is the obvious next
+# step for anyone running it, and there was no rule stopping them committing it.
+.env
+.env.*
+!.env.example
+
+# Python artifacts (dashboard/build.py and its tests)
+__pycache__/
+*.py[cod]
+.venv/
+venv/
+.pytest_cache/
+
 # Node artifacts (in case anyone adds tooling)
 node_modules/

--- a/dashboard/build.py
+++ b/dashboard/build.py
@@ -3167,13 +3167,33 @@ autoUnlock();
 
 
 def protect_with_password(html, password):
-    """Encrypt html with AES-256-GCM and wrap in a login page."""
+    """Encrypt html with AES-256-GCM and wrap in a login page.
+
+    Returns ONLY the login page: salt, nonce, and ciphertext. The plaintext —
+    including any injected write token — is never part of the output.
+
+    A missing `cryptography` is FATAL rather than a warning. It used to print a
+    warning and return the plaintext html, which meant the one case where the
+    caller had explicitly asked for protection was also the case where it
+    silently shipped an unprotected page. The build still succeeded, the page
+    still deployed, and the only signal was a line of stdout in a CI log nobody
+    reads. Refusing to build is the correct outcome: you asked for protection
+    and it cannot be delivered.
+    """
     try:
         from cryptography.hazmat.primitives.ciphers.aead import AESGCM
     except ImportError:
-        print("WARNING: 'cryptography' not installed — skipping password protection.")
-        print("         Run: pip install cryptography")
-        return html
+        raise SystemExit(
+            "REFUSING TO BUILD: DASHBOARD_PASSWORD is set but the 'cryptography'\n"
+            "package is not installed, so the page cannot be encrypted.\n"
+            "\n"
+            "Continuing would publish an UNPROTECTED page that you have every\n"
+            "reason to believe is protected.\n"
+            "\n"
+            "  Fix:  pip install cryptography\n"
+            "  Or:   unset DASHBOARD_PASSWORD to build an intentionally public page\n"
+            "        (only valid if GITHUB_WRITE_TOKEN is also unset)."
+        )
 
     salt  = os.urandom(32)
     nonce = os.urandom(12)
@@ -3227,17 +3247,48 @@ def build():
     html = html.replace("__WEEK__",     str(week))
     html = html.replace("__UPDATED__",      updated)
     html = html.replace("__DATA_JSON__",    json.dumps(data, ensure_ascii=False))
-    html = html.replace("__GITHUB_TOKEN__", os.environ.get("GITHUB_WRITE_TOKEN", ""))
+    # A GitHub WRITE token is inlined into the page as `window.GITHUB_TOKEN`, so
+    # whether the page ends up encrypted is not a display preference — it decides
+    # whether that credential is published in plaintext.
+    #
+    # These two env vars were previously independent: the token was substituted
+    # unconditionally, while encryption was conditional on DASHBOARD_PASSWORD. So
+    # setting GITHUB_WRITE_TOKEN alone published a live write token, in the clear,
+    # on a public GitHub Pages site that search engines crawl. Nothing warned.
+    #
+    # Binding them makes that combination unrepresentable rather than merely
+    # discouraged. It fails loudly at build time, before anything is deployed —
+    # the only point at which the mistake is still free to fix.
+    token    = os.environ.get("GITHUB_WRITE_TOKEN", "")
+    password = os.environ.get("DASHBOARD_PASSWORD")
+
+    if token and not password:
+        raise SystemExit(
+            "REFUSING TO BUILD: GITHUB_WRITE_TOKEN is set but DASHBOARD_PASSWORD is not.\n"
+            "\n"
+            "The token is inlined into the page as window.GITHUB_TOKEN. Without a\n"
+            "password the page is not encrypted, so this would publish a live GitHub\n"
+            "WRITE credential in plaintext at your Pages URL.\n"
+            "\n"
+            "  Fix:    set DASHBOARD_PASSWORD as well (the page is then AES-256-GCM\n"
+            "          encrypted and the token ships only inside the ciphertext).\n"
+            "  Or:     unset GITHUB_WRITE_TOKEN for a read-only dashboard.\n"
+            "\n"
+            "If a token was ever built and deployed this way, treat it as compromised\n"
+            "and rotate it — the page was public and may be cached or indexed."
+        )
+
+    html = html.replace("__GITHUB_TOKEN__", token)
     html = html.replace("__GITHUB_REPO__",  "owner/repo")
     html = html.replace("__TEAM_MEMBERS_JSON__", json.dumps(team_names))
     html = html.replace("__OWNER_CLS_JSON__",    json.dumps(team_owner_cls))
 
-    password = os.environ.get("DASHBOARD_PASSWORD")
     if password:
         html = protect_with_password(html, password)
         print("  Password protection: enabled")
     else:
         print("  Password protection: disabled (set DASHBOARD_PASSWORD to enable)")
+        print("  Write token:         absent (read-only dashboard)")
 
     out = os.path.join(DOCS_DIR, "index.html")
     with open(out, "w", encoding="utf-8") as f:

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -426,3 +426,91 @@ class TestMissingDataGraceful:
         html = out.read_text(encoding="utf-8")
         assert html.startswith("<!DOCTYPE html>")
         assert "tab-scorecard" in html  # tabs render even with empty datasets
+
+
+class TestWriteTokenNeverPublishedInPlaintext:
+    """COS-698 item 3 — the token and the password must not be independent.
+
+    `window.GITHUB_TOKEN` carries a GitHub WRITE credential. Before this, the
+    token was substituted unconditionally while encryption was conditional on
+    DASHBOARD_PASSWORD, so setting the token alone published a live write
+    credential in plaintext on a public Pages site. Nothing warned, and 54 forks
+    inherit the design.
+
+    These tests assert the two are BOUND, and — more importantly — that the
+    token never appears in bytes that get written to disk.
+    """
+
+    def test_token_without_password_refuses_to_build(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(build, "DOCS_DIR", str(tmp_path))
+        monkeypatch.setattr(build, "DATA_DIR", FIXTURES)
+        monkeypatch.setenv("GITHUB_WRITE_TOKEN", "ghp_TESTONLY_not_a_real_token")
+        monkeypatch.delenv("DASHBOARD_PASSWORD", raising=False)
+
+        with pytest.raises(SystemExit) as exc:
+            build.build()
+
+        assert "REFUSING TO BUILD" in str(exc.value)
+        # And nothing was written — a refusal that still emits the file is not a
+        # refusal, because Pages deploys whatever is in docs/.
+        assert not (tmp_path / "index.html").exists()
+
+    def test_token_with_password_never_reaches_the_written_file(self, monkeypatch, tmp_path):
+        """The real assertion: grep the OUTPUT for the token, not just for a marker.
+
+        Asserting 'encryption was enabled' would pass even if the token leaked
+        alongside the ciphertext. This checks the bytes on disk.
+        """
+        pytest.importorskip("cryptography")
+        monkeypatch.setattr(build, "DOCS_DIR", str(tmp_path))
+        monkeypatch.setattr(build, "DATA_DIR", FIXTURES)
+        token = "ghp_TESTONLY_not_a_real_token"
+        monkeypatch.setenv("GITHUB_WRITE_TOKEN", token)
+        monkeypatch.setenv("DASHBOARD_PASSWORD", "correct horse battery staple")
+
+        build.build()
+
+        written = (tmp_path / "index.html").read_text(encoding="utf-8")
+        assert token not in written, "write token leaked into the published page"
+        # Sanity: it really is the encrypted login page, not merely a page that
+        # happens not to contain the token.
+        assert "__CT__" not in written, "login template placeholder was left unsubstituted"
+        assert "DASHBOARD_DATA" not in written, "plaintext body leaked alongside the ciphertext"
+
+    def test_no_token_and_no_password_still_builds(self, monkeypatch, tmp_path):
+        """The common case — a public read-only dashboard — must be unaffected."""
+        monkeypatch.setattr(build, "DOCS_DIR", str(tmp_path))
+        monkeypatch.setattr(build, "DATA_DIR", FIXTURES)
+        monkeypatch.delenv("GITHUB_WRITE_TOKEN", raising=False)
+        monkeypatch.delenv("DASHBOARD_PASSWORD", raising=False)
+
+        build.build()
+
+        html = (tmp_path / "index.html").read_text(encoding="utf-8")
+        assert "window.GITHUB_TOKEN = ''" in html
+        assert "DASHBOARD_DATA" in html
+
+    def test_password_without_cryptography_refuses_rather_than_shipping_plaintext(
+        self, monkeypatch, tmp_path
+    ):
+        """The second live-fire path, which the audit did not name.
+
+        protect_with_password used to catch ImportError, print a warning, and
+        return the PLAINTEXT html. So the one case where protection was
+        explicitly requested was also the case where it silently shipped
+        unprotected — with a live token inside it.
+        """
+        import builtins
+        real_import = builtins.__import__
+
+        def no_cryptography(name, *args, **kwargs):
+            if name.startswith("cryptography"):
+                raise ImportError("simulated: cryptography not installed")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", no_cryptography)
+
+        with pytest.raises(SystemExit) as exc:
+            build.protect_with_password("<html>secret</html>", "pw")
+
+        assert "REFUSING TO BUILD" in str(exc.value)


### PR DESCRIPTION
## The bug (COS-698 item 3)

`dashboard/build.py` inlined the write token **unconditionally**:

```python
html = html.replace("__GITHUB_TOKEN__", os.environ.get("GITHUB_WRITE_TOKEN", ""))
```

…while encryption was **conditional**:

```python
password = os.environ.get("DASHBOARD_PASSWORD")
if password:
    html = protect_with_password(html, password)
```

The two env vars were independent. Setting `GITHUB_WRITE_TOKEN` alone published a live GitHub **write** credential in plaintext, as `window.GITHUB_TOKEN`, on a public GitHub Pages site that search engines crawl. Nothing warned.

**Inert as shipped today** — both secrets are unset, and the live page serves `window.GITHUB_TOKEN = ''` with zero crypto markers. But it is one repository secret away from firing, and every fork inherits the design.

## A second path, not named in the audit

`protect_with_password` caught `ImportError` on `cryptography`, printed a warning, and returned the **plaintext** html:

```python
except ImportError:
    print("WARNING: 'cryptography' not installed — skipping password protection.")
    return html          # <-- with the token in it
```

So the one case where protection was explicitly requested was also the case where it silently shipped unprotected. The build succeeded, the page deployed, and the only signal was a line of stdout in a CI log. Now fatal: if you asked for protection and it cannot be delivered, refusing is correct.

## The fix

Both combinations now fail at **build time**, before anything deploys — the last moment the mistake is still free to fix. The unsafe state is unrepresentable rather than merely discouraged.

Note `protect_with_password` genuinely protects the token: AES-256-GCM with PBKDF2-HMAC-SHA256 at 100k iterations, returning **only** salt, nonce, and ciphertext. The plaintext never reaches the output. That is what makes the coupling meaningful rather than cosmetic.

## Also: missing `.env` rules (COS-698 item 6)

Nothing has leaked — no `.env` exists in any commit of this repo. But the build reads two secrets from the environment, so a local `.env` is the obvious next step for anyone running it, and there was no rule stopping them committing it. Added, along with Python artifacts (`__pycache__` was showing up untracked).

## Testing

4 new cases:

| Test | Pre-fix | Post-fix |
|---|---|---|
| token without password refuses | **FAILED** | passed |
| password without `cryptography` refuses | **FAILED** | passed |
| token+password never reaches the written file | passed | passed |
| no token, no password still builds | passed | passed |

The two bug-catching cases were each **observed failing** against the pre-fix `build.py`. The two that pass against both are non-regression guards, which is what makes them guards rather than duplicates.

The leak test greps the **bytes written to disk** for the token rather than asserting "encryption was enabled" — the latter would pass even if the token leaked alongside the ciphertext.

**Pre-existing failures, not touched here:** 3 unrelated failures in `TestLoadAllRocks` and `test_full_build`, verified identical on a stashed clean tree (49 passed / 3 failed before, 53 passed / same 3 failed after).